### PR TITLE
Create mock/prod versions of some things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
 - '0.10'
+before_script:
+- npm test
+- export IRC_PROD=true
 after_script:
 - npm run coveralls
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '0.10'
 before_script:
 - npm test
-- export IRC_PROD=true
+- export IRC_ENV=integration
 after_script:
 - npm run coveralls
 env:

--- a/lib/client.js
+++ b/lib/client.js
@@ -94,4 +94,4 @@ function prod() {
   );
 }
 
-module.exports = (process.env.IRC_PROD === 'true') ? prod() : mock();
+module.exports = (process.env.IRC_ENV === 'production') ? prod() : mock();

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,7 @@
 'use strict';
 
-function mockClient(ircUser) {
+function mock() {
+  var ircUser = 'testbot';
   return {
     _channels: {},
     _nicks: {},
@@ -81,4 +82,16 @@ function mockClient(ircUser) {
   };
 }
 
-module.exports = mockClient;
+function prod() {
+  var irc = require('irc');
+  var client = new irc.Client(
+    process.env.IRC_HOST,
+    process.env.IRC_USER,
+    {
+      password: process.env.IRC_PASS,
+      channels: process.env.IRC_CHANNELS.split(',')
+    }
+  );
+}
+
+module.exports = (process.env.IRC_PROD === 'true') ? prod() : mock();

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var request = require('sync-request');
+
+function messageListener(db, from, channel, message) {
+
+  db.scala = db.scala || {};
+  db.scala.headers = db.scala.headers || {};
+
+  if (/^https?:\/\/[^ ]+$/.test(message)) {
+    var res = request('GET', message);
+    var match = /<title>(.+)<\/title>/.exec(res.getBody().toString().replace(/\n/g, ''));
+    if (match) {
+      var decoded = match[1].replace(/&#\d+;/gm,function(s) {
+        return String.fromCharCode(s.match(/\d+/gm)[0]);
+      });
+      return [ { to: channel, message: decoded } ] ;
+    }
+  }
+}
+
+function mock() {
+  return function(db, url) {
+    if (url === 'http://stackoverflow.com/questions/11037123/%C3%A9-html-entity-code-in-title-tags') {
+      return '<title>é HTML Entity code in title tags - Stack Overflow</title>';
+    } else if (url === 'https://www.google.com/') {
+      return '<title>Google</title>';
+    }
+  };
+}
+
+function prod() {
+  return function(db, url) {
+    return request('GET', url).getBody().toString().replace(/\n/g, '');
+  };
+}
+
+module.exports = (process.env.IRC_PROD === 'true') ? prod() : mock();

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -35,4 +35,4 @@ function prod() {
   };
 }
 
-module.exports = (process.env.IRC_PROD === 'true') ? prod() : mock();
+module.exports = (process.env.IRC_ENV === undefined) ? mock() : prod();

--- a/lib/listeners/message/http-title.js
+++ b/lib/listeners/message/http-title.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var request = require('sync-request');
+var httpclient = require('../../http-client');
 
 function messageListener(db, from, channel, message) {
 
@@ -8,8 +8,8 @@ function messageListener(db, from, channel, message) {
   db.scala.headers = db.scala.headers || {};
 
   if (/^https?:\/\/[^ ]+$/.test(message)) {
-    var res = request('GET', message);
-    var match = /<title>(.+)<\/title>/.exec(res.getBody().toString().replace(/\n/g, ''));
+    var res = httpclient(db, message);
+    var match = /<title>(.+)<\/title>/.exec(res);
     if (match) {
       var decoded = match[1].replace(/&#\d+;/gm,function(s) {
         return String.fromCharCode(s.match(/\d+/gm)[0]);

--- a/lib/listeners/message/scala.js
+++ b/lib/listeners/message/scala.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var request = require('sync-request');
+var scala = require('../../scala');
 
 function messageListener(db, from, channel, message) {
 
@@ -10,18 +10,8 @@ function messageListener(db, from, channel, message) {
   if (/^@scala/.test(message)) {
     var match = /^@scala\s+(.+)$/.exec(message);
     if (match) {
-      var encoded = encodeURIComponent(match[1]);
-      var res = request(
-        'GET',
-        'http://www.simplyscala.com/interp?bot=irc&code=' + encoded,
-        { headers: db.scala.headers, }
-      );
-      if (res.statusCode !== 200) {
-        db.scala.headers.cookie = {};
-      } else if (res.headers && res.headers['set-cookie']) {
-        db.scala.headers.cookie = res.headers['set-cookie'];
-      }
-      return [ { to: channel, message: res.getBody().toString().replace(/\n+$/, '') } ];
+      var res = scala(db, match[1]);
+      return [ { to: channel, message: res } ] ;
     } else {
       return [ { to: channel, message: 'Usage: @scala <expression>' } ];
     }

--- a/lib/scala.js
+++ b/lib/scala.js
@@ -28,4 +28,4 @@ function prod() {
   };
 }
 
-module.exports = (process.env.IRC_PROD === 'true') ? prod() : mock();
+module.exports = (process.env.IRC_ENV === undefined) ? mock() : prod();

--- a/lib/scala.js
+++ b/lib/scala.js
@@ -1,0 +1,31 @@
+'use strict';
+
+function mock() {
+  return function(db, src) {
+    if (src === '2 + 3') {
+      return 'res0: Int = 5';
+    } else {
+      return 'res1: Int = 12';
+    }
+  };
+}
+
+function prod() {
+  var request = require('sync-request');
+  return function(db, src) {
+    var encoded = encodeURIComponent(src);
+    var res = request(
+      'GET',
+      'http://www.simplyscala.com/interp?bot=irc&code=' + encoded,
+      { headers: db.scala.headers, }
+    );
+    if (res.statusCode !== 200) {
+      db.scala.headers.cookie = {};
+    } else if (res.headers && res.headers['set-cookie']) {
+      db.scala.headers.cookie = res.headers['set-cookie'];
+    }
+    return res.getBody().toString().replace(/\n+$/, '');
+  };
+}
+
+module.exports = (process.env.IRC_PROD === 'true') ? prod() : mock();

--- a/sectery.js
+++ b/sectery.js
@@ -2,7 +2,7 @@
 
 var sectery = require('./lib/sectery');
 
-[ 'IRC_PROD', 'IRC_HOST', 'IRC_USER', 'IRC_PASS', 'IRC_CHANNELS', ].forEach(
+[ 'IRC_ENV', 'IRC_HOST', 'IRC_USER', 'IRC_PASS', 'IRC_CHANNELS', ].forEach(
   function (x) {
     if (process.env[x] === undefined) {
         console.log('Please set ' + x + ' and try again.');                      

--- a/sectery.js
+++ b/sectery.js
@@ -1,24 +1,15 @@
 'use strict';
 
-var irc     = require('irc');
 var sectery = require('./lib/sectery');
 
-var client;
-
-[ 'IRC_HOST', 'IRC_USER', 'IRC_PASS', 'IRC_CHANNELS', ].forEach(function (x) {
-  if (process.env[x] === undefined) {
-      console.log('Please set ' + x + ' and try again.');                      
-      process.exit();                                                                
-  }  
-});
-
-var client = new irc.Client(
-  process.env.IRC_HOST,
-  process.env.IRC_USER,
-  {
-    password: process.env.IRC_PASS,
-    channels: process.env.IRC_CHANNELS.split(',')
+[ 'IRC_PROD', 'IRC_HOST', 'IRC_USER', 'IRC_PASS', 'IRC_CHANNELS', ].forEach(
+  function (x) {
+    if (process.env[x] === undefined) {
+        console.log('Please set ' + x + ' and try again.');                      
+        process.exit();                                                                
+    }  
   }
 );
 
+var client = sectery(require('./lib/client'));
 sectery(client);

--- a/test/sectry_test.js
+++ b/test/sectry_test.js
@@ -4,7 +4,7 @@
 var lib = process.env.LIB_COV ? 'lib-cov' : 'lib';
 
 var sectery = require('../' + lib + '/sectery');
-var client  = require('./mock-client')('testbot');
+var client  = require('../lib/client');
 
 sectery(client);
 


### PR DESCRIPTION
This makes tests run **so much faster**.  Fixes #4.

Usage: some code (e.g. the @scala message listener) asks for one of the abstracted clients (e.g. the scala client), and it gets a mock one if the IRC_PROD env var is not set to *true*, else it gets the production one that goes out to the real Internets.