### PR TITLE
Allow message bursts of up to five at a time

### DIFF
--- a/lib/sectery.js
+++ b/lib/sectery.js
@@ -33,18 +33,6 @@ function sectery(client) {
   db.cron = [];
 
   var replyQueue = [];
-
-  var replyInterval = setInterval(function () {
-    var reply = replyQueue.shift();
-    if (reply) {
-      if (reply.callback) {
-        reply.callback(client.say.bind(client));
-      } else if (reply.to && reply.message) {
-        client.say(reply.to, reply.message);
-      }
-    }
-  }, 2000);
-
   function reply(replies) {
     if (replies) {
       replies.forEach(function (reply) {
@@ -53,6 +41,34 @@ function sectery(client) {
     }
     saveDb(db);
   }
+
+  var replyTimes = [];
+  function floodLimited() {
+    var now = (new Date().getTime());
+    var newReplyTimes = [];
+    for (var i = 0; i < replyTimes.length; i++) {
+      var replyTime = replyTimes[i];
+      if (now - replyTime < 10 * 1000) {
+        newReplyTimes.push(replyTime);
+      }
+    }
+    replyTimes = newReplyTimes;
+    return (replyTimes.length >= 5);
+  }
+
+  var replyInterval = setInterval(function () {
+    if (!floodLimited()) {
+      var reply = replyQueue.shift();
+      if (reply) {
+        replyTimes.push((new Date()).getTime());
+        if (reply.callback) {
+          reply.callback(client.say.bind(client));
+        } else if (reply.to && reply.message) {
+          client.say(reply.to, reply.message);
+        }
+      }
+    }
+  }, 250);
 
   client.addListener('join', function (channel, nick, message) {
     function run(joinListener) {


### PR DESCRIPTION
Based on [these recommendations][1]:

> The rule of thumb is 2 seconds per line, and that includes lines
> without content, like PINGs. The algorithm allows for bursts up to 5
> at once (in a 10 second span).

This could use some refactoring for beauty, but the idea is to send
replies every 250ms, without exceeding five messages in a ten second
span.

This mostly ignores the *2 seconds per line* guideline, since that is
covered by *up to 5 in a 10 second span*.  I'm not sure whether that's
bending the rules.

[1]: https://www.reddit.com/r/irc/comments/1rdejj/freenode_flood_limits/cdm7jo9