### PR TITLE
Fix ascii blink regex to match non blink command

### DIFF
--- a/lib/listeners/message/ascii-text.js
+++ b/lib/listeners/message/ascii-text.js
@@ -25,7 +25,7 @@ function messageListener(db, from, channel, message, reply) {
   var ascii_regex = /^@ascii +[^ ]/;
 
   if (ascii_regex.test(message) && !img_regex.test(message)) {
-    var cmd = message.match(/^@ascii +(blink)? +([^ ].*)$/);
+    var cmd = message.match(/^@ascii +(blink *)?([^ ].*)$/);
     var formatLine = cmd[1] ? util.blink_text : function(s) { return s; };
     var text = cmd[2];
     var ascii = figlet.textSync(text, {


### PR DESCRIPTION
```text
@ascii blink foo
```

worked, but not

```text
@ascii foo
```

do to previous regex looking for two spaces minimum before the text, when blink option was absent.