### PR TITLE
Add a ZIO-based message queueing system

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ Sectery is an digital assistant IRC bot.
 
 * https://github.com/pircbotx/pircbotx
 * https://pircbotx.github.io/pircbotx/2.2/apidocs/index.html
+
+### ZIO
+
+* https://zio.dev/docs/overview/overview_index
+* https://javadoc.io/doc/dev.zio/zio_2.12/1.0.8/zio/index.html

--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -1,0 +1,78 @@
+package sectery
+
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.concurrent.TimeUnit
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import zio.clock.Clock
+import zio.duration._
+import zio.Fiber
+import zio.Queue
+import zio.Schedule
+import zio.UIO
+import zio.URIO
+import zio.ZIO
+import zio.ZQueue
+
+/**
+ * A message received from IRC.
+ */
+case class Rx(channel: String, nick: String, message: String)
+
+/**
+ * A message to send to IRC.
+ */
+case class Tx(channel: String, message: String)
+
+/**
+ * Read incoming messages, and optionally produce a response.
+ */
+object Producer {
+  def apply(m: Rx): Iterable[Tx] =
+    m match
+      case Rx(c, _, "@ping") =>
+        Some(Tx(c, "pong"))
+      case _ =>
+        None
+}
+
+/**
+ * An interface for defining how to send an outgoing message, which
+ * varies between testing and production.
+ */
+trait Sender:
+  def send(m: Tx): UIO[Unit]
+
+/**
+ * Read received messages from a queue, process them, queue them for
+ * sending, and send them at a throttled rate.
+ */
+object MessageQueues:
+
+  private def produce(inbox: Queue[Rx], outbox: Queue[Tx]): UIO[Unit] =
+    for
+      size    <- inbox.size
+      message <- inbox.take
+      txs      = Producer(message)
+      _       <- ZIO.collectAll(txs.map(outbox.offer))
+    yield ()
+
+  private def send(outbox: Queue[Tx], sender: Sender): UIO[Unit] =
+    for
+      message <- outbox.take
+      _       <- sender.send(message)
+    yield ()
+
+  def loop(sender: Sender): URIO[Clock, Queue[Rx]] =
+    for
+      inbox  <- ZQueue.unbounded[Rx]
+      outbox <- ZQueue.unbounded[Tx]
+      _      <- produce(inbox, outbox)
+                  .forever
+                  .fork
+      _      <- send(outbox, sender)
+                  .repeat(Schedule.spaced(250.milliseconds))
+                  .fork
+    yield inbox

--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -1,0 +1,35 @@
+package sectery
+
+import java.io.IOException
+import zio._
+import zio.clock._
+import zio.duration._
+import zio.test._
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestClock
+
+/**
+ * A [[Sender]] implementation for testing.  Saves "sent" messages to a
+ * queue for later inspection.
+ */
+class MessageLogger(queue: Queue[Tx]) extends Sender {
+  def send(m: Tx): UIO[Unit] =
+    queue.offer(m) *> ZIO.unit
+}
+
+/**
+ * Tests the management of the receive and send message queues.
+ */
+object MessageQueuesSpec extends DefaultRunnableSpec {
+  def spec = suite("MessageQueuesSpec")(
+    testM("@ping produces pong") {
+      for
+        sent   <- ZQueue.unbounded[Tx]
+        inbox  <- MessageQueues.loop(new MessageLogger(sent))
+        _      <- inbox.offer(Rx("#foo", "bar", "@ping"))
+        _      <- TestClock.adjust(1.seconds)
+        m      <- sent.take
+      yield assert(m)(equalTo(Tx("#foo", "pong")))
+    }
+  )
+}


### PR DESCRIPTION
This sets up a queue for incoming messages received from IRC, a queue
for outgoing messages to be throttled and sent to IRC, a process for
reading and responding to messages, and a loop to manage the whole
thing.