### PR TITLE
Add support for @time

### DIFF
--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -30,6 +30,16 @@ object MessageQueuesSpec extends DefaultRunnableSpec {
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
       yield assert(m)(equalTo(Tx("#foo", "pong")))
+    },
+    testM("@time produces time") {
+      for
+        sent   <- ZQueue.unbounded[Tx]
+        inbox  <- MessageQueues.loop(new MessageLogger(sent))
+        _      <- TestClock.setTime(1234567890.millis)
+        _      <- inbox.offer(Rx("#foo", "bar", "@time"))
+        _      <- TestClock.adjust(1.seconds)
+        m      <- sent.take
+      yield assert(m)(equalTo(Tx("#foo", "Wed, 14 Jan 1970, 23:56 MST")))
     }
   )
 }


### PR DESCRIPTION
This introduces [`zio.clock.Clock`][1] into the environment of the
message producer so that we can manage time during testing to write
deterministic tests.

[1]: https://javadoc.io/static/dev.zio/zio_2.12/1.0.8/zio/clock/index.html#Clock=zio.Has[zio.clock.package.Clock.Service]