### PR TITLE
Connect the IRC bot to the message queueing system

### DIFF
--- a/src/main/scala/sectery/Bot.scala
+++ b/src/main/scala/sectery/Bot.scala
@@ -1,0 +1,54 @@
+package sectery
+
+import javax.net.ssl.SSLSocketFactory
+import org.pircbotx.Configuration
+import org.pircbotx.hooks.events.MessageEvent
+import org.pircbotx.hooks.ListenerAdapter
+import org.pircbotx.hooks.types.GenericMessageEvent
+import org.pircbotx.PircBotX
+import scala.collection.JavaConverters._
+import zio.UIO
+import zio.ZIO
+
+object Bot extends Sender:
+
+  var receive: Rx => Unit = { _ => () }
+
+  private val config: Configuration =
+    new Configuration.Builder()
+      .setSocketFactory(SSLSocketFactory.getDefault())
+      .setName(sys.env("IRC_USER"))
+      .setRealName(sys.env("IRC_USER"))
+      .setLogin(sys.env("IRC_USER"))
+      .setNickservPassword(sys.env("IRC_PASS"))
+      .addServer(sys.env("IRC_HOST"), sys.env("IRC_PORT").toInt)
+      .addAutoJoinChannels(
+        sys.env("IRC_CHANNELS")
+          .split(",")
+          .map(_.trim)
+          .toIterable.asJava
+      )
+      .addListener(
+        new ListenerAdapter {
+          override def onGenericMessage(event: GenericMessageEvent): Unit =
+            event match
+              case e: MessageEvent =>
+                val m =
+                  Rx(
+                    channel = e.getChannel().getName(),
+                    nick = e.getUser().getNick(),
+                    message = e.getMessage()
+                  )
+                receive(m)
+        }
+      )
+      .buildConfiguration()
+
+  private val bot: PircBotX =
+    new PircBotX(config)
+
+  override def send(m: Tx): UIO[Unit] =
+    ZIO.effectTotal(bot.sendIRC.message(m.channel, m.message))
+
+  def start(): Unit =
+    bot.startBot()

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -1,36 +1,22 @@
 package sectery
 
-import org.pircbotx.Configuration
-import org.pircbotx.hooks.ListenerAdapter
-import org.pircbotx.hooks.events.MessageEvent
-import org.pircbotx.hooks.types.GenericMessageEvent
-import org.pircbotx.PircBotX
+import zio.App
+import zio.ExitCode
+import zio.UIO
+import zio.URIO
+import zio.ZEnv
+import zio.ZIO
 
-class SecteryListener extends ListenerAdapter {
-  override def onGenericMessage(event: GenericMessageEvent): Unit =
-    event match
-      case e: MessageEvent =>
-        if e.getMessage() == "@ping" then
-          e.respondChannel("pong")
-}
+object Sectery extends App:
 
-object Sectery extends scala.App {
-  import scala.collection.JavaConverters._
-  val configuration: Configuration =
-    new Configuration.Builder()
-      .setName(sys.env("IRC_USER"))
-      .setRealName(sys.env("IRC_USER"))
-      .setLogin(sys.env("IRC_USER"))
-      .setNickservPassword(sys.env("IRC_PASS"))
-      .addServer(sys.env("IRC_HOST"))
-      .addAutoJoinChannels(
-        sys.env("IRC_CHANNELS")
-          .split(",")
-          .map(_.trim)
-          .toIterable.asJava
-      )
-      .addListener(new SecteryListener())
-      .buildConfiguration()
-  val bot: PircBotX = new PircBotX(configuration)
-  bot.startBot()
-}
+  /**
+   * 1. Spin up the message queues using [[Bot]] as the [[Sender]]
+   * 2. Asynchronously process received messages through [[Bot.receive]]
+   * 3. Connect to IRC
+   */
+  def run(args: List[String]): URIO[ZEnv, ExitCode] =
+    for
+      inbox <- sectery.MessageQueues.loop(Bot)
+      _      = Bot.receive = (m: Rx) => unsafeRunAsync_(inbox.offer(m))
+      _      = Bot.start()
+    yield ExitCode.failure // should never exit


### PR DESCRIPTION
This swaps out the sample PircBotX listener adapter with the ZIO-based
inbox/producer/outbox message queuing system, and hooks it up to the bot
instance.