### PR TITLE
Extract message producers into their own classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@ Sectery is an digital assistant IRC bot.
 
 ## Producer
 
-Message responses are coded in `Producer.apply` in
-<src/main/scala/sectery/MessageQueues.scala>.
+Message responses are coded in the [`Producer`][1] implementations in
+the [`sectery.producers` package][2].
 
-To add support for a new message response, add a `Rx => URIO[Clock,
-Iterable[Tx]]` case to `Producer.apply`:
+To add support for a new message response, write a new `Producer`
+implementation, and add it to the list of producers in
+[`Producer.producers`][1].
 
-```scala
-case Rx(c, _, "@foo") =>
-  ZIO.effectTotal(Some(Tx(c, "bar")))
-```
+[1]: src/main/scala/sectery/Producer.scala
+[2]: src/main/scala/sectery/producers/
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Sectery is an digital assistant IRC bot.
 
 ## Producer
 
-Message responses are coded in the [`Producer`][1] implementations in
-the [`sectery.producers` package][2].
+Message responses are coded in the [`Producer`][Producer.scala]
+implementations in the [`sectery.producers` package][sectery.producers].
 
 To add support for a new message response, write a new `Producer`
 implementation, and add it to the list of producers in
-[`Producer.producers`][1].
+[`Producer.producers`][Producer.scala].
 
-[1]: src/main/scala/sectery/Producer.scala
-[2]: src/main/scala/sectery/producers/
+[Producer.scala]: src/main/scala/sectery/Producer.scala
+[sectery.producers]: src/main/scala/sectery/producers/
 
 ## References
 

--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -1,14 +1,7 @@
 package sectery
 
-import java.io.IOException
-import java.text.SimpleDateFormat
-import java.util.concurrent.TimeUnit
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
 import zio.clock.Clock
 import zio.duration._
-import zio.Fiber
 import zio.Queue
 import zio.Schedule
 import zio.UIO
@@ -25,26 +18,6 @@ case class Rx(channel: String, nick: String, message: String)
  * A message to send to IRC.
  */
 case class Tx(channel: String, message: String)
-
-/**
- * Read incoming messages, and produce any number of responses.
- */
-object Producer {
-  def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
-    m match
-      case Rx(c, _, "@ping") =>
-        ZIO.effectTotal(Some(Tx(c, "pong")))
-      case Rx(c, _, "@time") =>
-        for
-          millis <- zio.clock.currentTime(TimeUnit.MILLISECONDS)
-          date    = new Date(millis)
-          sdf     = new SimpleDateFormat("EEE, d MMM yyyy, kk:mm zzz")
-          _       = sdf.setTimeZone(TimeZone.getTimeZone("America/Phoenix"))
-          pretty  = sdf.format(date)
-        yield Some(Tx(c, pretty))
-      case _ =>
-        ZIO.effectTotal(None)
-}
 
 /**
  * An interface for defining how to send an outgoing message, which

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -1,0 +1,25 @@
+package sectery
+
+import sectery.producers._
+import zio.URIO
+import zio.ZIO
+import zio.clock.Clock
+
+/**
+ * Reads an incoming message, and produces any number of responses.
+ */
+trait Producer:
+  def apply(m: Rx): URIO[Clock, Iterable[Tx]]
+
+object Producer:
+
+  private val producers: List[Producer] =
+    List(
+      Ping,
+      Time
+    )
+
+  def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
+    ZIO.foldLeft(producers)(List.empty) {
+      (txs, p) => p.apply(m).map(_.toList).map(_ ++ txs)
+    }

--- a/src/main/scala/sectery/producers/Ping.scala
+++ b/src/main/scala/sectery/producers/Ping.scala
@@ -1,0 +1,16 @@
+package sectery.producers
+
+import sectery.Producer
+import sectery.Rx
+import sectery.Tx
+import zio.clock.Clock
+import zio.URIO
+import zio.ZIO
+
+object Ping extends Producer:
+  def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
+    m match
+      case Rx(c, _, "@ping") =>
+        ZIO.effectTotal(Some(Tx(c, "pong")))
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -1,0 +1,26 @@
+package sectery.producers
+
+import java.text.SimpleDateFormat
+import java.util.concurrent.TimeUnit
+import java.util.Date
+import java.util.TimeZone
+import sectery.Producer
+import sectery.Rx
+import sectery.Tx
+import zio.clock.Clock
+import zio.URIO
+import zio.ZIO
+
+object Time extends Producer:
+  def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
+    m match
+      case Rx(c, _, "@time") =>
+        for
+          millis <- zio.clock.currentTime(TimeUnit.MILLISECONDS)
+          date    = new Date(millis)
+          sdf     = new SimpleDateFormat("EEE, d MMM yyyy, kk:mm zzz")
+          _       = sdf.setTimeZone(TimeZone.getTimeZone("America/Phoenix"))
+          pretty  = sdf.format(date)
+        yield Some(Tx(c, pretty))
+      case _ =>
+        ZIO.effectTotal(None)


### PR DESCRIPTION
This takes the quickly-growing pattern match in `Producer.apply`, and
splits it into individual classes under the `sectery.producers` package.

Adding new producers now consists of writing a new `Producer`
implementation, and then adding it to the list of producers in
`Producer.producers`.