### PR TITLE
Add support for @eval and an HTTP service for ZIO

### DIFF
--- a/src/main/scala/sectery/Http.scala
+++ b/src/main/scala/sectery/Http.scala
@@ -1,0 +1,96 @@
+package sectery
+
+import java.net.HttpURLConnection
+import java.net.URL
+import scala.collection.JavaConverters._
+import scala.io.Source
+import zio.Has
+import zio.UIO
+import zio.ULayer
+import zio.URIO
+import zio.ZIO
+import zio.ZLayer
+
+case class Response(
+  status: Int,
+  headers: Map[String, String],
+  body: String
+)
+
+object Http:
+
+  type Http = Has[Http.Service]
+
+  trait Service:
+    def request(
+      method: String,
+      url: String,
+      headers: Map[String, String],
+      body: Option[String]
+    ): UIO[Response]
+
+  val live: ULayer[Has[Service]] =
+    ZLayer.succeed {
+      new Service:
+        def request(
+          method: String,
+          url: String,
+          headers: Map[String, String],
+          body: Option[String]
+        ): UIO[Response] =
+
+          ZIO.effectTotal {
+            val c =
+              new URL(url)
+                .openConnection()
+                .asInstanceOf[HttpURLConnection]
+
+            c.setInstanceFollowRedirects(false)
+            c.setRequestMethod(method)
+            c.setDoInput(true)
+            c.setDoOutput(body.isDefined)
+
+            headers foreach {
+              case (k, v) =>
+                c.setRequestProperty(k, v)
+            }
+
+            body foreach { b =>
+              c.getOutputStream.write(b.getBytes("UTF-8"))
+            }
+
+            val response =
+              Response(
+                status = c.getResponseCode(),
+                headers =
+                  c
+                    .getHeaderFields()
+                    .asScala
+                    .filter({ case (k, _) => k != null })
+                    .map({ case (k, v) => (k, v.asScala.mkString(",")) })
+                    .toMap - "Date" - "Content-Length" - "Server",
+                body =
+                  Source
+                    .fromInputStream {
+                      if (c.getResponseCode() < 400) {
+                        c.getInputStream
+                      } else {
+                        c.getErrorStream
+                      }
+                    }
+                    .mkString
+              )
+
+            c.disconnect()
+
+            response
+          }
+    }
+
+  def request(
+    method: String,
+    url: String,
+    headers: Map[String, String],
+    body: Option[String]
+  ): URIO[Http, Response] =
+    ZIO.accessM(_.get.request(method, url, headers, body))

--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -2,6 +2,7 @@ package sectery
 
 import zio.clock.Clock
 import zio.duration._
+import zio.Has
 import zio.Queue
 import zio.Schedule
 import zio.UIO
@@ -32,7 +33,7 @@ trait Sender:
  */
 object MessageQueues:
 
-  private def produce(inbox: Queue[Rx], outbox: Queue[Tx]): URIO[Clock, Unit] =
+  private def produce(inbox: Queue[Rx], outbox: Queue[Tx]): URIO[Clock with Http.Http, Unit] =
     for
       size    <- inbox.size
       message <- inbox.take
@@ -46,7 +47,7 @@ object MessageQueues:
       _       <- sender.send(message)
     yield ()
 
-  def loop(sender: Sender): URIO[Clock, Queue[Rx]] =
+  def loop(sender: Sender): URIO[Clock with Http.Http, Queue[Rx]] =
     for
       inbox  <- ZQueue.unbounded[Rx]
       outbox <- ZQueue.unbounded[Tx]

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -1,25 +1,27 @@
 package sectery
 
 import sectery.producers._
+import zio.clock.Clock
+import zio.Has
 import zio.URIO
 import zio.ZIO
-import zio.clock.Clock
 
 /**
  * Reads an incoming message, and produces any number of responses.
  */
 trait Producer:
-  def apply(m: Rx): URIO[Clock, Iterable[Tx]]
+  def apply(m: Rx): URIO[Clock with Http.Http, Iterable[Tx]]
 
 object Producer:
 
   private val producers: List[Producer] =
     List(
       Ping,
-      Time
+      Time,
+      Eval
     )
 
-  def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
+  def apply(m: Rx): URIO[Clock with Http.Http, Iterable[Tx]] =
     ZIO.foldLeft(producers)(List.empty) {
       (txs, p) => p.apply(m).map(_.toList).map(_ ++ txs)
     }

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -1,11 +1,15 @@
 package sectery
 
 import zio.App
+import zio.clock.Clock
 import zio.ExitCode
+import zio.Has
 import zio.UIO
+import zio.ULayer
 import zio.URIO
 import zio.ZEnv
 import zio.ZIO
+import zio.ZLayer
 
 object Sectery extends App:
 
@@ -16,7 +20,7 @@ object Sectery extends App:
    */
   def run(args: List[String]): URIO[ZEnv, ExitCode] =
     for
-      inbox <- sectery.MessageQueues.loop(Bot)
+      inbox <- sectery.MessageQueues.loop(Bot).provideLayer(ZEnv.live ++ Http.live)
       _      = Bot.receive = (m: Rx) => unsafeRunAsync_(inbox.offer(m))
       _      = Bot.start()
     yield ExitCode.failure // should never exit

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -1,0 +1,34 @@
+package sectery.producers
+
+import java.net.URLEncoder
+import sectery.Http
+import sectery.Producer
+import sectery.Response
+import sectery.Rx
+import sectery.Tx
+import zio.clock.Clock
+import zio.Has
+import zio.URIO
+import zio.ZIO
+
+object Eval extends Producer:
+
+  val eval = """^@eval\s+(.+)\s*$""".r
+
+  def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+    m match
+      case Rx(c, _, eval(expr)) =>
+        val encExpr = URLEncoder.encode(expr, "UTF-8")
+        Http.request(
+          method = "GET",
+          url = s"https://earldouglas.com/api/haskeval?src=${encExpr}",
+          headers = Map.empty,
+          body = None
+        ).map {
+          case Response(200, _, body) =>
+            Some(Tx(c, body))
+          case r =>
+            None
+        }
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -7,39 +7,80 @@ import zio.duration._
 import zio.test._
 import zio.test.Assertion.equalTo
 import zio.test.environment.TestClock
+import zio.test.TestAspect._
+import zio.ULayer
+import zio.ZLayer
 
 /**
  * A [[Sender]] implementation for testing.  Saves "sent" messages to a
  * queue for later inspection.
  */
-class MessageLogger(queue: Queue[Tx]) extends Sender {
+class MessageLogger(queue: Queue[Tx]) extends Sender:
   def send(m: Tx): UIO[Unit] =
     queue.offer(m) *> ZIO.unit
-}
 
 /**
  * Tests the management of the receive and send message queues.
  */
-object MessageQueuesSpec extends DefaultRunnableSpec {
+object MessageQueuesSpec extends DefaultRunnableSpec:
   def spec = suite("MessageQueuesSpec")(
     testM("@ping produces pong") {
       for
         sent   <- ZQueue.unbounded[Tx]
-        inbox  <- MessageQueues.loop(new MessageLogger(sent))
+        inbox  <- MessageQueues.loop(new MessageLogger(sent)).provideLayer(Clock.any ++ TestHttp())
         _      <- inbox.offer(Rx("#foo", "bar", "@ping"))
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
       yield assert(m)(equalTo(Tx("#foo", "pong")))
-    },
+    } @@ timeout(2.seconds),
     testM("@time produces time") {
       for
         sent   <- ZQueue.unbounded[Tx]
-        inbox  <- MessageQueues.loop(new MessageLogger(sent))
+        inbox  <- MessageQueues.loop(new MessageLogger(sent)).provideLayer(Clock.any ++ TestHttp())
         _      <- TestClock.setTime(1234567890.millis)
         _      <- inbox.offer(Rx("#foo", "bar", "@time"))
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
       yield assert(m)(equalTo(Tx("#foo", "Wed, 14 Jan 1970, 23:56 MST")))
-    }
+    } @@ timeout(2.seconds),
+    testM("@eval produces result") {
+      for
+        sent   <- ZQueue.unbounded[Tx]
+        inbox  <- MessageQueues.loop(new MessageLogger(sent)).provideLayer(Clock.any ++ TestHttp(200, Map.empty, "42"))
+        _      <- inbox.offer(Rx("#foo", "bar", "@eval 6 * 7"))
+        _      <- TestClock.adjust(1.seconds)
+        m      <- sent.take
+      yield assert(m)(equalTo(Tx("#foo", "42")))
+    } @@ timeout(2.seconds)
   )
-}
+
+object TestHttp:
+
+  def apply(): ULayer[Has[Http.Service]] =
+    apply(
+      resStatus = 200,
+      resHeaders = Map.empty,
+      resBody = ""
+    )
+
+  def apply(
+    resStatus: Int,
+    resHeaders: Map[String, String],
+    resBody: String
+  ): ULayer[Has[Http.Service]] =
+    ZLayer.succeed {
+      new Http.Service:
+        def request(
+          method: String,
+          url: String,
+          headers: Map[String, String],
+          body: Option[String]
+        ): UIO[Response] =
+          ZIO.effectTotal {
+            Response(
+              status = resStatus,
+              headers = resHeaders,
+              body = resBody
+            )
+          }
+    }


### PR DESCRIPTION
This adds support for `@eval`, which passes its argument to Haskeval.
This also adds a new ZIO service for making HTTP requests, and a way to
mock responses for ZIO Test.