### PR TITLE
Change Http.Service.request from UIO to Task

### DIFF
--- a/src/main/scala/sectery/Http.scala
+++ b/src/main/scala/sectery/Http.scala
@@ -5,9 +5,9 @@ import java.net.URL
 import scala.collection.JavaConverters._
 import scala.io.Source
 import zio.Has
-import zio.UIO
+import zio.RIO
+import zio.Task
 import zio.ULayer
-import zio.URIO
 import zio.ZIO
 import zio.ZLayer
 
@@ -27,7 +27,7 @@ object Http:
       url: String,
       headers: Map[String, String],
       body: Option[String]
-    ): UIO[Response]
+    ): Task[Response]
 
   val live: ULayer[Has[Service]] =
     ZLayer.succeed {
@@ -37,9 +37,9 @@ object Http:
           url: String,
           headers: Map[String, String],
           body: Option[String]
-        ): UIO[Response] =
+        ): Task[Response] =
 
-          ZIO.effectTotal {
+          ZIO.effect {
             val c =
               new URL(url)
                 .openConnection()
@@ -92,5 +92,5 @@ object Http:
     url: String,
     headers: Map[String, String],
     body: Option[String]
-  ): URIO[Http, Response] =
+  ): RIO[Http, Response] =
     ZIO.accessM(_.get.request(method, url, headers, body))

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -29,6 +29,8 @@ object Eval extends Producer:
             Some(Tx(c, body))
           case r =>
             None
-        }
+        }.catchAll { e =>
+            ZIO.effectTotal(None)
+        }.map(_.toIterable)
       case _ =>
         ZIO.effectTotal(None)


### PR DESCRIPTION
The Http.live  implementation uses a lot of the `java.net._` API, which
throws all kinds of exceptions.  This changes the effect type
accordingly, so that if something goes wrong we can decide how to handle
it from within the `Producer` implementation.  For now, we shrug it off
and do nothing.
