### PR TITLE
Add support for partial environment injection

### DIFF
--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -33,7 +33,7 @@ trait Sender:
  */
 object MessageQueues:
 
-  private def produce(inbox: Queue[Rx], outbox: Queue[Tx]): URIO[Clock with Http.Http, Unit] =
+  private def produce(inbox: Queue[Rx], outbox: Queue[Tx]): URIO[Http.Http with Clock, Unit] =
     for
       size    <- inbox.size
       message <- inbox.take
@@ -47,7 +47,7 @@ object MessageQueues:
       _       <- sender.send(message)
     yield ()
 
-  def loop(sender: Sender): URIO[Clock with Http.Http, Queue[Rx]] =
+  def loop(sender: Sender): URIO[Http.Http with Clock, Queue[Rx]] =
     for
       inbox  <- ZQueue.unbounded[Rx]
       outbox <- ZQueue.unbounded[Tx]

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -2,7 +2,6 @@ package sectery
 
 import sectery.producers._
 import zio.clock.Clock
-import zio.Has
 import zio.URIO
 import zio.ZIO
 
@@ -10,7 +9,7 @@ import zio.ZIO
  * Reads an incoming message, and produces any number of responses.
  */
 trait Producer:
-  def apply(m: Rx): URIO[Clock with Http.Http, Iterable[Tx]]
+  def apply(m: Rx): URIO[Http.Http with Clock, Iterable[Tx]]
 
 object Producer:
 
@@ -21,7 +20,7 @@ object Producer:
       Eval
     )
 
-  def apply(m: Rx): URIO[Clock with Http.Http, Iterable[Tx]] =
+  def apply(m: Rx): URIO[Http.Http with Clock, Iterable[Tx]] =
     ZIO.foldLeft(producers)(List.empty) {
       (txs, p) => p.apply(m).map(_.toList).map(_ ++ txs)
     }

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -20,7 +20,7 @@ object Sectery extends App:
    */
   def run(args: List[String]): URIO[ZEnv, ExitCode] =
     for
-      inbox <- sectery.MessageQueues.loop(Bot).provideLayer(ZEnv.live ++ Http.live)
+      inbox <- sectery.MessageQueues.loop(Bot).provideLayer(ZEnv.any ++ Http.live)
       _      = Bot.receive = (m: Rx) => unsafeRunAsync_(inbox.offer(m))
       _      = Bot.start()
     yield ExitCode.failure // should never exit


### PR DESCRIPTION
This allows a `Has[R0]` to be injected into a `ZIO[Has[R0] with Has[R1],
E, A]`, yielding a `Zio[Has[R1], E, A]`.

This change allows `Clock` instances to be excluded from the explicit
environment provided in test code, since zio-test already includes that
in the test environment.