### PR TITLE
Add support for describing HTML from http(s) URLs

### DIFF
--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -17,7 +17,8 @@ object Producer:
     List(
       Ping,
       Time,
-      Eval
+      Eval,
+      Html
     )
 
   def apply(m: Rx): URIO[Http.Http with Clock, Iterable[Tx]] =

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -1,0 +1,60 @@
+package sectery.producers
+
+import java.net.URLEncoder
+import sectery.Http
+import sectery.Producer
+import sectery.Response
+import sectery.Rx
+import sectery.Tx
+import zio.clock.Clock
+import zio.Has
+import zio.URIO
+import zio.ZIO
+
+object Html extends Producer:
+
+  val url = """.*(http[^\s]+).*""".r
+
+  val desc = """.*<\s*meta\s+name="description"\s+content="([^"]+)"\s*>.*""".r
+  val ogDesc1 = """.*<\s*meta\s+property="og:description"\s+content="([^"]+)"\s*>.*""".r
+  val ogDesc2 = """.*<\s*meta\s+name="og:description"\s+content="([^"]+)"\s*>.*""".r
+  val twitDesc1 = """.*<\s*meta\s+property="twitter:description"\s+content="([^"]+)"\s*>.*""".r
+  val twitDesc2 = """.*<\s*meta\s+name="twitter:description"\s+content="([^"]+)"\s*>.*""".r
+
+  val title = """.*<\s*title>\s*(.+)\s*<\/title>.*""".r
+  val ogTitle1 = """.*<\s*meta\s+property="og:title"\s+content="([^"]+)"\s*>.*""".r
+  val ogTitle2 = """.*<\s*meta\s+name="og:title"\s+content="([^"]+)"\s*>.*""".r
+  val twitTitle1 = """.*<\s*meta\s+property="twitter:title"\s+content="([^"]+)"\s*>.*""".r
+  val twitTitle2 = """.*<\s*meta\s+name="twitter:title"\s+content="([^"]+)"\s*>.*""".r
+
+  def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+    m match
+      case Rx(c, _, url(url)) =>
+        Http.request(
+          method = "GET",
+          url = url,
+          headers = Map.empty,
+          body = None
+        ).map {
+          case Response(200, _, body) =>
+            body
+              .replaceAll("[\\r\\n]", " ")
+              .replaceAll("\\s+", " ") match
+              case desc(d) => Some(Tx(c, d))
+              case ogDesc1(d) => Some(Tx(c, d))
+              case ogDesc2(d) => Some(Tx(c, d))
+              case twitDesc1(d) => Some(Tx(c, d))
+              case twitDesc2(d) => Some(Tx(c, d))
+              case title(t) => Some(Tx(c, t))
+              case ogTitle1(t) => Some(Tx(c, t))
+              case ogTitle2(t) => Some(Tx(c, t))
+              case twitTitle1(t) => Some(Tx(c, t))
+              case twitTitle2(t) => Some(Tx(c, t))
+              case _ => None
+          case r =>
+            None
+        }.catchAll { e =>
+            ZIO.effectTotal(None)
+        }.map(_.toIterable)
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -57,5 +57,51 @@ object MessageQueuesSpec extends DefaultRunnableSpec:
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
       yield assert(m)(equalTo(Tx("#foo", "42")))
+    } @@ timeout(2.seconds),
+    testM("URL produces description from HTML") {
+      for
+        sent   <- ZQueue.unbounded[Tx]
+        http    = sys.env.get("TEST_HTTP_LIVE") match
+                    case Some("true") => Http.live
+                    case _ =>
+                      val http: ULayer[Has[Http.Service]] =
+                        ZLayer.succeed {
+                          new Http.Service:
+                            def request(
+                              method: String,
+                              url: String,
+                              headers: Map[String, String],
+                              body: Option[String]
+                            ): UIO[Response] =
+                              url match
+                                case "https://earldouglas.com/posts/scala.html" =>
+                                  ZIO.effectTotal {
+                                    Response(
+                                      status = 200,
+                                      headers = Map.empty,
+                                      body = """|<html>
+                                                |  <head>
+                                                |    <meta   name="description"   content="Some notes on the Scala language, 
+                                                |libraries, and ecosystem."  >
+                                                |  </head>
+                                                |</html>
+                                                |""".stripMargin
+                                    )
+                                  }
+                                case _ =>
+                                  ZIO.effectTotal {
+                                    Response(
+                                      status = 404,
+                                      headers = Map.empty,
+                                      body = ""
+                                    )
+                                  }
+                        }
+                      http
+        inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(http)
+        _      <- inbox.offer(Rx("#foo", "bar", "foo bar https://earldouglas.com/posts/scala.html baz"))
+        _      <- TestClock.adjust(1.seconds)
+        m      <- sent.take
+      yield assert(m)(equalTo(Tx("#foo", "Some notes on the Scala language, libraries, and ecosystem.")))
     } @@ timeout(2.seconds)
   )


### PR DESCRIPTION
This detects http(s) URLs, fetches them, and tries to pull out a
description or title to respond to the channel with.  This uses a lot of
hacktastic regexes, but it kind of works.  A follow-up could be
replacing the regexes with a civilized HTML parser.