### PR TITLE
Add a non-empty User-Agent header

### DIFF
--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -33,7 +33,7 @@ object Html extends Producer:
         Http.request(
           method = "GET",
           url = url,
-          headers = Map.empty,
+          headers = Map("User-Agent" -> "bot"),
           body = None
         ).map {
           case Response(200, _, body) =>


### PR DESCRIPTION
Some CDNs throw a 403 if they receive a request without a User-Agent
header.  This sets it to `bot` just so that it's non-empty.