### PR TITLE
Replace HTML regex parsing with jsoup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val root = project
   .settings(
     name := "sectery",
     scalaVersion := scala3Version,
+    libraryDependencies += "org.jsoup" % "jsoup" % "1.13.1",
     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3",
     libraryDependencies += "com.github.pircbotx" % "pircbotx" % "2.2",
     libraryDependencies += "dev.zio" %% "zio" % zioVersion,


### PR DESCRIPTION
This uses an actual HTML parser to look for page metadata, which will
have a better hit rate than any set of regular expressions.