### PR TITLE
Get the regex substitution producer working

### DIFF
--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -18,7 +18,8 @@ object Producer:
       Ping,
       Time,
       Eval,
-      Html
+      Html,
+      Substitute
     )
 
   def apply(m: Rx): URIO[Http.Http with Clock, Iterable[Tx]] =

--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -103,5 +103,15 @@ object MessageQueuesSpec extends DefaultRunnableSpec:
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
       yield assert(m)(equalTo(Tx("#foo", "Some notes on the Scala language, libraries, and ecosystem.")))
+    } @@ timeout(2.seconds),
+    testM("s/bar/baz/ replaces bar with baz") {
+      for
+        sent   <- ZQueue.unbounded[Tx]
+        inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestHttp())
+        _      <- inbox.offer(Rx("#foo", "bar", "foobar"))
+        _      <- inbox.offer(Rx("#foo", "baz", "s/bar/baz/"))
+        _      <- TestClock.adjust(1.seconds)
+        m      <- sent.take
+      yield assert(m)(equalTo(Tx("#foo", "foobaz")))
     } @@ timeout(2.seconds)
   )


### PR DESCRIPTION
1. Enable it in `Producer.producers`
2. Add a test
3. Don't limit candidates to the nick sending the regex
4. Save the updated per-nick messages data