### PR TITLE
Apply substitute to the first matching message

### DIFF
--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -108,10 +108,13 @@ object MessageQueuesSpec extends DefaultRunnableSpec:
       for
         sent   <- ZQueue.unbounded[Tx]
         inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestHttp())
-        _      <- inbox.offer(Rx("#foo", "bar", "foobar"))
-        _      <- inbox.offer(Rx("#foo", "baz", "s/bar/baz/"))
+        _      <- inbox.offer(Rx("#foo", "foo", "1: foo"))
+        _      <- inbox.offer(Rx("#foo", "bar", "2: bar"))
+        _      <- inbox.offer(Rx("#foo", "baz", "3: baz"))
+        _      <- inbox.offer(Rx("#foo", "raz", "4: raz"))
+        _      <- inbox.offer(Rx("#foo", "qux", "s/bar/baz/"))
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
-      yield assert(m)(equalTo(Tx("#foo", "foobaz")))
+      yield assert(m)(equalTo(Tx("#foo", "<bar> 2: baz")))
     } @@ timeout(2.seconds)
   )


### PR DESCRIPTION
This fixes a bug where `Substitute` will try to replace any message
received, regardless of whether it matches the replacement pattern.