### PR TITLE
Add support for SQLite persistence, @count

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val root = project
   .settings(
     name := "sectery",
     scalaVersion := scala3Version,
+    libraryDependencies += "org.xerial" % "sqlite-jdbc" % "3.34.0",
     libraryDependencies += "org.jsoup" % "jsoup" % "1.13.1",
     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3",
     libraryDependencies += "com.github.pircbotx" % "pircbotx" % "2.2",

--- a/src/main/scala/sectery/Db.scala
+++ b/src/main/scala/sectery/Db.scala
@@ -1,0 +1,24 @@
+package sectery
+
+import java.sql._
+import zio._
+
+object Db:
+
+  type Db = Has[Db.Service]
+
+  trait Service:
+    def query[A](k: Connection => A): Task[A]
+
+  val live: ULayer[Has[Service]] =
+    ZLayer.succeed {
+      new Service:
+        Class.forName("org.sqlite.JDBC");
+        lazy val conn: Connection =
+          DriverManager.getConnection("jdbc:sqlite:sectery.db")
+        override def query[A](k: Connection => A): Task[A] =
+          ZIO.effect(k(conn))
+    }
+
+  def query[A](k: Connection => A): RIO[Db, A] =
+    ZIO.accessM(_.get.query(k))

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -2,14 +2,22 @@ package sectery
 
 import sectery.producers._
 import zio.clock.Clock
+import zio.RIO
 import zio.URIO
 import zio.ZIO
 
-/**
- * Reads an incoming message, and produces any number of responses.
- */
 trait Producer:
-  def apply(m: Rx): URIO[Http.Http with Clock, Iterable[Tx]]
+
+  /**
+   * Run any initialization (e.g. run DDL) needed.
+   */
+  def init(): RIO[Db.Db with Http.Http with Clock, Unit] =
+    ZIO.effectTotal(())
+
+  /**
+   * Reads an incoming message, and produces any number of responses.
+   */
+  def apply(m: Rx): URIO[Db.Db with Http.Http with Clock, Iterable[Tx]]
 
 object Producer:
 
@@ -19,10 +27,14 @@ object Producer:
       Time,
       Eval,
       Html,
-      Substitute
+      Substitute,
+      Count
     )
 
-  def apply(m: Rx): URIO[Http.Http with Clock, Iterable[Tx]] =
+  def init(): RIO[Db.Db with Http.Http with Clock, Iterable[Unit]] =
+    ZIO.foreach(producers)(_.init())
+
+  def apply(m: Rx): URIO[Db.Db with Http.Http with Clock, Iterable[Tx]] =
     ZIO.foldLeft(producers)(List.empty) {
       (txs, p) => p.apply(m).map(_.toList).map(_ ++ txs)
     }

--- a/src/main/scala/sectery/producers/Count.scala
+++ b/src/main/scala/sectery/producers/Count.scala
@@ -1,0 +1,61 @@
+package sectery.producers
+
+import sectery.Db
+import sectery.Producer
+import sectery.Rx
+import sectery.Tx
+import zio.RIO
+import zio.UIO
+import zio.URIO
+import zio.ZIO
+
+object Count extends Producer:
+  override def init(): RIO[Db.Db, Unit] =
+    for
+      _ <- Db.query { conn =>
+        val s = "CREATE TABLE IF NOT EXISTS COUNTER(VALUE INT NOT NULL)"
+        val stmt = conn.createStatement
+        stmt.executeUpdate(s)
+        stmt.close
+      }
+    yield ()
+
+  override def apply(m: Rx): URIO[Db.Db, Iterable[Tx]] =
+    m match
+      case Rx(channel, _, "@count") =>
+        val increment =
+          for
+            oldCount <- Db.query { conn =>
+              val q = "SELECT VALUE FROM COUNTER LIMIT 1"
+              val stmt = conn.createStatement
+              val rs = stmt.executeQuery(q)
+              val count =
+                if (rs.next()) {
+                  rs.getInt("VALUE")
+                } else {
+                  0
+                }
+              stmt.close
+              count
+            }
+            _ <- Db.query { conn =>
+              val s = "DELETE FROM COUNTER"
+              val stmt = conn.createStatement
+              stmt.executeUpdate(s)
+              stmt.close
+            }
+            newCount <- Db.query { conn =>
+              val count = oldCount + 1
+              val s = "INSERT INTO COUNTER (VALUE) VALUES (?)"
+              val stmt = conn.prepareStatement(s)
+              stmt.setInt(1, count)
+              stmt.executeUpdate
+              stmt.close
+              count
+            }
+          yield Some(Tx(channel, s"${newCount}"))
+        increment.catchAll { e =>
+          ZIO.effectTotal(None)
+        }.map(_.toIterable)
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -12,10 +12,8 @@ import zio.URIO
 import zio.ZIO
 
 object Eval extends Producer:
-
-  val eval = """^@eval\s+(.+)\s*$""".r
-
-  def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+  private val eval = """^@eval\s+(.+)\s*$""".r
+  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, eval(expr)) =>
         val encExpr = URLEncoder.encode(expr, "UTF-8")

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -16,9 +16,9 @@ import zio.ZIO
 
 object Html extends Producer:
 
-  val url = """.*(http[^\s]+).*""".r
+  private val url = """.*(http[^\s]+).*""".r
 
-  def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, url(url)) =>
         Http.request(

--- a/src/main/scala/sectery/producers/Ping.scala
+++ b/src/main/scala/sectery/producers/Ping.scala
@@ -8,7 +8,7 @@ import zio.URIO
 import zio.ZIO
 
 object Ping extends Producer:
-  def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
+  override def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
     m match
       case Rx(c, _, "@ping") =>
         ZIO.effectTotal(Some(Tx(c, "pong")))

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -12,7 +12,7 @@ import zio.URIO
 import zio.ZIO
 
 object Time extends Producer:
-  def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
+  override def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
     m match
       case Rx(c, _, "@time") =>
         for

--- a/src/test/scala/sectery/TestDb.scala
+++ b/src/test/scala/sectery/TestDb.scala
@@ -1,0 +1,20 @@
+package sectery
+
+import java.sql.Connection
+import java.sql.DriverManager
+import zio.Has
+import zio.Task
+import zio.ULayer
+import zio.ZIO
+import zio.ZLayer
+
+object TestDb:
+  def apply(): ULayer[Has[Db.Service]] =
+    ZLayer.succeed {
+      new Db.Service:
+        Class.forName("org.sqlite.JDBC");
+        lazy val conn: Connection =
+          DriverManager.getConnection(s"jdbc:sqlite::memory:")
+        override def query[A](k: Connection => A): Task[A] =
+          ZIO.effect(k(conn))
+    }


### PR DESCRIPTION
This adds a new database service `Db` that wraps SQLite, and a producer
that responds to `@count` as an example of how to use it.

It's currently up to each producer to deal with isolation from other
producers, and between channels and nicks, as well as transaction
management.  These are all potential areas for improvement of the
`Db` service.