### PR TITLE
Isolate tests for Substitute to own IRC channel

### DIFF
--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -114,11 +114,11 @@ object MessageQueuesSpec extends DefaultRunnableSpec:
       for
         sent   <- ZQueue.unbounded[Tx]
         inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestDb(), TestHttp())
-        _      <- inbox.offer(Rx("#foo", "foo", "1: foo"))
-        _      <- inbox.offer(Rx("#foo", "bar", "2: bar"))
-        _      <- inbox.offer(Rx("#foo", "baz", "3: baz"))
-        _      <- inbox.offer(Rx("#foo", "raz", "4: raz"))
-        _      <- inbox.offer(Rx("#foo", "qux", "s/bar/baz/"))
+        _      <- inbox.offer(Rx("#substitute", "foo", "1: foo"))
+        _      <- inbox.offer(Rx("#substitute", "bar", "2: bar"))
+        _      <- inbox.offer(Rx("#substitute", "baz", "3: baz"))
+        _      <- inbox.offer(Rx("#substitute", "raz", "4: raz"))
+        _      <- inbox.offer(Rx("#substitute", "qux", "s/bar/baz/"))
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
       yield assert(m)(equalTo(Tx("#foo", "<bar> 2: baz")))

--- a/src/test/scala/sectery/MessageQueuesSpec.scala
+++ b/src/test/scala/sectery/MessageQueuesSpec.scala
@@ -121,7 +121,7 @@ object MessageQueuesSpec extends DefaultRunnableSpec:
         _      <- inbox.offer(Rx("#substitute", "qux", "s/bar/baz/"))
         _      <- TestClock.adjust(1.seconds)
         m      <- sent.take
-      yield assert(m)(equalTo(Tx("#foo", "<bar> 2: baz")))
+      yield assert(m)(equalTo(Tx("#substitute", "<bar> 2: baz")))
     } @@ timeout(2.seconds),
     testM("@count produces count") {
       for


### PR DESCRIPTION
This test can fail depending on the order of execution of the other
tests, as the "last message" entry can be overwritten by the "bar" user
in the same channel on another test.