### PR TITLE
Add support for @stock

### DIFF
--- a/src/main/scala/sectery/Finnhub.scala
+++ b/src/main/scala/sectery/Finnhub.scala
@@ -1,0 +1,76 @@
+package sectery
+
+import org.slf4j.LoggerFactory
+import zio.Has
+import zio.RIO
+import zio.Task
+import zio.ULayer
+import zio.ZIO
+import zio.ZLayer
+
+case class Quote(
+  open: Float,
+  high: Float,
+  low: Float,
+  current: Float,
+  previousClose: Float
+)
+
+object Finnhub:
+
+  type Finnhub = Has[Finnhub.Service]
+
+  trait Service:
+    def quote(symbol: String): Task[Option[Quote]]
+
+  val live: ULayer[Has[Service]] =
+    ZLayer.succeed {
+      new Service:
+        private lazy val token: String = sys.env("FINNHUB_API_TOKEN")
+        def quote(symbol: String): Task[Option[Quote]] =
+          ZIO.effect {
+            Http.unsafeRequest(
+              method = "GET",
+              url = s"""https://finnhub.io/api/v1/quote?symbol=${symbol}&token=${token}""",
+              headers = Map.empty,
+              body = None
+            ) match
+              case Response(200, _, body) =>
+                // TODO this is awful, but I can't find a JSON parser that supports Scala 3
+                val fields: Map[String, String] =
+                  body
+                    .replaceAll("""["{}\s\n\r]""", "")
+                    .split(",")
+                    .map(_.split(":"))
+                    .map(xs => xs(0) -> xs(1))
+                    .toMap
+                for {
+                  o  <- fields.get("o").map(_.toFloat)
+                  h  <- fields.get("h").map(_.toFloat)
+                  l  <- fields.get("l").map(_.toFloat)
+                  c  <- fields.get("c").map(_.toFloat)
+                  pc <- fields.get("pc").map(_.toFloat)
+                  q  <- (o, h, l, c, pc) match
+                          case (0, 0, 0, 0, 0) =>
+                            None
+                          case _ =>
+                            Some(
+                              Quote(
+                                open = o,
+                                high = h,
+                                low = l,
+                                current = c,
+                                previousClose = pc
+                              )
+                            )
+                } yield q
+              case _ =>
+                None
+          }.catchAll { e =>
+            LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
+            ZIO.effectTotal(None)
+          }
+    }
+
+  def quote(symbol: String): RIO[Finnhub, Option[Quote]] =
+    ZIO.accessM(_.get.quote(symbol))

--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -34,7 +34,7 @@ trait Sender:
  */
 object MessageQueues:
 
-  private def produce(inbox: Queue[Rx], outbox: Queue[Tx]): URIO[Db.Db with Http.Http with Clock, Unit] =
+  private def produce(inbox: Queue[Rx], outbox: Queue[Tx]): URIO[Producer.Env, Unit] =
     for
       size    <- inbox.size
       message <- inbox.take
@@ -48,7 +48,7 @@ object MessageQueues:
       _       <- sender.send(message)
     yield ()
 
-  def loop(sender: Sender): RIO[Db.Db with Http.Http with Clock, Queue[Rx]] =
+  def loop(sender: Sender): RIO[Producer.Env, Queue[Rx]] =
     for
       _      <- Producer.init()
       inbox  <- ZQueue.unbounded[Rx]

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -16,15 +16,14 @@ object Sectery extends App:
    * 3. Connect to IRC
    */
   def run(args: List[String]): URIO[ZEnv, ExitCode] =
-    val go: RIO[Db.Db with Http.Http with Clock, Unit] =
+    val go: RIO[Producer.Env, Unit] =
       for
-        inbox <- MessageQueues
-                   .loop(Bot)
+        inbox <- MessageQueues.loop(Bot)
         _      = Bot.receive = (m: Rx) => unsafeRunAsync_(inbox.offer(m))
         _      = Bot.start()
       yield ()  
     go
-      .provideLayer(ZEnv.any ++ Db.live ++ Http.live)
+      .provideLayer(ZEnv.any ++ Finnhub.live ++ Db.live ++ Http.live)
       .catchAll { e =>
         ZIO.effectTotal(())
       }.map { _ =>

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -1,0 +1,34 @@
+package sectery.producers
+
+import sectery.Finnhub
+import sectery.Producer
+import sectery.Response
+import sectery.Rx
+import sectery.Tx
+import zio.clock.Clock
+import zio.Has
+import zio.URIO
+import zio.UIO
+import zio.Task
+import zio.ZIO
+
+object Stock extends Producer:
+  private val stock = """^@stock\s+([^\s]+)\s*$""".r
+  override def apply(m: Rx): URIO[Finnhub.Finnhub, Iterable[Tx]] =
+    m match
+      case Rx(c, _, stock(symbol)) =>
+        Finnhub
+          .quote(symbol)
+          .map {
+            case Some(q) =>
+              val current = q.current
+              val change = q.current - q.previousClose
+              val changeP = change * 100 / q.previousClose
+              Some(Tx(c, f"""${symbol}: ${current}%.2f ${change}%+.2f (${changeP}%+.2f%%)"""))
+            case None =>
+              Some(Tx(c, s"${symbol}: stonk not found"))
+          }.catchAll { _ =>
+            ZIO.effectTotal(None)
+          }.map(_.toIterable)
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/test/scala/sectery/TestFinnhub.scala
+++ b/src/test/scala/sectery/TestFinnhub.scala
@@ -1,0 +1,31 @@
+package sectery
+
+import java.sql.Connection
+import java.sql.DriverManager
+import zio.Has
+import zio.Task
+import zio.ULayer
+import zio.ZIO
+import zio.ZLayer
+
+object TestFinnhub:
+  def apply(): ULayer[Has[Finnhub.Service]] =
+    ZLayer.succeed {
+      new Finnhub.Service:
+        override def quote(symbol: String): Task[Option[Quote]] =
+          symbol match
+            case "FOO" =>
+              ZIO.effectTotal(
+                Some(
+                  Quote(
+                    open = 5,
+                    high = 7,
+                    low = 4,
+                    current = 6,
+                    previousClose = 4
+                  )
+                )
+              )
+            case _ =>
+              ZIO.effectTotal(None)
+    }

--- a/src/test/scala/sectery/producers/Count.scala
+++ b/src/test/scala/sectery/producers/Count.scala
@@ -15,7 +15,7 @@ object CountSpec extends DefaultRunnableSpec:
     testM("@count produces count") {
       for
         sent   <- ZQueue.unbounded[Tx]
-        inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestDb(), TestHttp())
+        inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), TestHttp())
         _      <- inbox.offer(Rx("#foo", "bar", "@count"))
         _      <- inbox.offer(Rx("#foo", "bar", "@count"))
         _      <- inbox.offer(Rx("#foo", "bar", "@count"))

--- a/src/test/scala/sectery/producers/Eval.scala
+++ b/src/test/scala/sectery/producers/Eval.scala
@@ -18,7 +18,7 @@ object EvalSpec extends DefaultRunnableSpec:
           http    = sys.env.get("TEST_HTTP_LIVE") match
                       case Some("true") => Http.live
                       case _ => TestHttp(200, Map.empty, "42")
-          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestDb(), http)
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), http)
           _      <- inbox.offer(Rx("#foo", "bar", "@eval 6 * 7"))
           _      <- TestClock.adjust(1.seconds)
           m      <- sent.take

--- a/src/test/scala/sectery/producers/Html.scala
+++ b/src/test/scala/sectery/producers/Html.scala
@@ -52,7 +52,7 @@ object HtmlSpec extends DefaultRunnableSpec:
                                     }
                           }
                         http
-          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestDb(), http)
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), http)
           _      <- inbox.offer(Rx("#foo", "bar", "foo bar https://earldouglas.com/posts/scala.html baz"))
           _      <- TestClock.adjust(1.seconds)
           m      <- sent.take

--- a/src/test/scala/sectery/producers/Ping.scala
+++ b/src/test/scala/sectery/producers/Ping.scala
@@ -15,7 +15,7 @@ object PingSpec extends DefaultRunnableSpec:
       testM("@ping produces pong") {
         for
           sent   <- ZQueue.unbounded[Tx]
-          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestDb(), TestHttp())
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), TestHttp())
           _      <- inbox.offer(Rx("#foo", "bar", "@ping"))
           _      <- TestClock.adjust(1.seconds)
           m      <- sent.take

--- a/src/test/scala/sectery/producers/Stock.scala
+++ b/src/test/scala/sectery/producers/Stock.scala
@@ -1,0 +1,32 @@
+package sectery.producers
+
+import sectery._
+import zio._
+import zio.duration._
+import zio.Inject._
+import zio.test._
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestClock
+import zio.test.TestAspect._
+
+object StockSpec extends DefaultRunnableSpec:
+  override def spec =
+    suite(getClass().getName())(
+      testM("@stock FOO produces quote") {
+        for
+          sent   <- ZQueue.unbounded[Tx]
+          fh      = sys.env.get("TEST_FINNHUB_LIVE") match
+                      case Some("true") => Finnhub.live
+                      case _ => TestFinnhub()
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(fh, TestDb(), TestHttp())
+          _      <- inbox.offer(Rx("#foo", "bar", "@stock FOO"))
+          _      <- inbox.offer(Rx("#foo", "bar", "@stock BAR"))
+          _      <- TestClock.adjust(1.seconds)
+          m1     <- sent.take
+          m2     <- sent.take
+        yield assert((m1, m2))(equalTo((
+          Tx("#foo", "FOO: 6.00 +2.00 (+50.00%)")),
+          Tx("#foo", "BAR: stonk not found"))
+        )
+      } @@ timeout(2.seconds)
+    )

--- a/src/test/scala/sectery/producers/Substitute.scala
+++ b/src/test/scala/sectery/producers/Substitute.scala
@@ -15,7 +15,7 @@ object SubstituteSpec extends DefaultRunnableSpec:
       testM("s/bar/baz/ replaces bar with baz") {
         for
           sent   <- ZQueue.unbounded[Tx]
-          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestDb(), TestHttp())
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), TestHttp())
           _      <- inbox.offer(Rx("#substitute", "foo", "1: foo"))
           _      <- inbox.offer(Rx("#substitute", "bar", "2: bar"))
           _      <- inbox.offer(Rx("#substitute", "baz", "3: baz"))

--- a/src/test/scala/sectery/producers/Time.scala
+++ b/src/test/scala/sectery/producers/Time.scala
@@ -15,7 +15,7 @@ object TimeSpec extends DefaultRunnableSpec:
       testM("@time produces time") {
         for
           sent   <- ZQueue.unbounded[Tx]
-          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestDb(), TestHttp())
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), TestHttp())
           _      <- TestClock.setTime(1234567890.millis)
           _      <- inbox.offer(Rx("#foo", "bar", "@time"))
           _      <- TestClock.adjust(1.seconds)

--- a/src/test/scala/zio/Inject.scala
+++ b/src/test/scala/zio/Inject.scala
@@ -13,3 +13,9 @@ object Inject:
       ZIO.fromFunctionM { r =>
         z.provideLayer(r0 ++ r1 ++ ZLayer.succeedMany(r))
       }
+
+  implicit class Inject4[R0, R1, R2, R3, E, A](z: ZIO[Has[R0] with Has[R1] with Has[R2] with Has[R3], E, A])(implicit t1: Tag[Has[R1]], t2: Tag[Has[R2]], t3: Tag[Has[R3]]):
+    def inject(r0: ULayer[Has[R0]], r1: ULayer[Has[R1]], r2: ULayer[Has[R2]]): ZIO[Has[R3], E, A] =
+      ZIO.fromFunctionM { r =>
+        z.provideLayer(r0 ++ r1 ++ r2 ++ ZLayer.succeedMany(r))
+      }


### PR DESCRIPTION
This includes a new service `Finnhub` that requires an environment
variable `FINNHUB_API_TOKEN` in the live implementation.  This also
replaces the ever-growing `Finnhub.Finnhub with Db.Db with Http.Http
with Clock` envrionment type with a type alias `Producer.Env` for
brevity.
