### PR TITLE
Add error logging of caught exceptions

### DIFF
--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -1,5 +1,6 @@
 package sectery
 
+import org.slf4j.LoggerFactory
 import zio.App
 import zio.clock.Clock
 import zio.ExitCode
@@ -25,6 +26,7 @@ object Sectery extends App:
     go
       .provideLayer(ZEnv.any ++ Finnhub.live ++ Db.live ++ Http.live)
       .catchAll { e =>
+        LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
         ZIO.effectTotal(())
       }.map { _ =>
         ExitCode.failure // should never exit

--- a/src/main/scala/sectery/producers/Count.scala
+++ b/src/main/scala/sectery/producers/Count.scala
@@ -1,5 +1,6 @@
 package sectery.producers
 
+import org.slf4j.LoggerFactory
 import sectery.Db
 import sectery.Producer
 import sectery.Rx
@@ -55,6 +56,7 @@ object Count extends Producer:
             }
           yield Some(Tx(channel, s"${newCount}"))
         increment.catchAll { e =>
+          LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
           ZIO.effectTotal(None)
         }.map(_.toIterable)
       case _ =>

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -1,5 +1,6 @@
 package sectery.producers
 
+import org.slf4j.LoggerFactory
 import java.net.URLEncoder
 import sectery.Http
 import sectery.Producer
@@ -28,7 +29,8 @@ object Eval extends Producer:
           case r =>
             None
         }.catchAll { e =>
-            ZIO.effectTotal(None)
+          LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
+          ZIO.effectTotal(None)
         }.map(_.toIterable)
       case _ =>
         ZIO.effectTotal(None)

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -1,5 +1,6 @@
 package sectery.producers
 
+import org.slf4j.LoggerFactory
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -32,7 +33,8 @@ object Html extends Producer:
           case r =>
             None
         }.catchAll { e =>
-            ZIO.effectTotal(None)
+          LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
+          ZIO.effectTotal(None)
         }.map(_.toIterable)
       case _ =>
         ZIO.effectTotal(None)

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -1,5 +1,6 @@
 package sectery.producers
 
+import org.slf4j.LoggerFactory
 import sectery.Finnhub
 import sectery.Producer
 import sectery.Response
@@ -28,6 +29,7 @@ object Stock extends Producer:
             case None =>
               Some(Tx(c, s"${symbol}: stonk not found"))
           }.catchAll { _ =>
+            LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
             ZIO.effectTotal(None)
           }.map(_.toIterable)
       case _ =>

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -28,7 +28,7 @@ object Stock extends Producer:
               Some(Tx(c, f"""${symbol}: ${current}%.2f ${change}%+.2f (${changeP}%+.2f%%)"""))
             case None =>
               Some(Tx(c, s"${symbol}: stonk not found"))
-          }.catchAll { _ =>
+          }.catchAll { e =>
             LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
             ZIO.effectTotal(None)
           }.map(_.toIterable)


### PR DESCRIPTION
This logs at the error level all exceptions caught by a `catchAll`.