### PR TITLE
Automatically capitalize stock symbols on lookup

### DIFF
--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -19,7 +19,7 @@ object Stock extends Producer:
     m match
       case Rx(c, _, stock(symbol)) =>
         Finnhub
-          .quote(symbol)
+          .quote(symbol.toUpperCase())
           .map {
             case Some(q) =>
               val current = q.current


### PR DESCRIPTION
This relaxes the restriction on the user to format stock symbols using
all caps.