### PR TITLE
Don't forget to actually interpolate the string

### DIFF
--- a/src/main/scala/sectery/Db.scala
+++ b/src/main/scala/sectery/Db.scala
@@ -16,7 +16,7 @@ object Db:
         Class.forName("org.sqlite.JDBC");
         lazy val dbPath = sys.env("SECTERY_DB")
         lazy val conn: Connection =
-          DriverManager.getConnection("""jdbc:sqlite:${dbPath}""")
+          DriverManager.getConnection(s"jdbc:sqlite:${dbPath}")
         override def query[A](k: Connection => A): Task[A] =
           ZIO.effect(k(conn))
     }


### PR DESCRIPTION
Configuring the database path via an env var was added in #167, but
without interpolation the connection string fails to use it.  This fixes
that.