### PR TITLE
Add support for looking up the weather report

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val root = project
   .settings(
     name := "sectery",
     scalaVersion := scala3Version,
+    libraryDependencies += "org.json4s" %% "json4s-native-core" % "4.0.0",
     libraryDependencies += "org.xerial" % "sqlite-jdbc" % "3.34.0",
     libraryDependencies += "org.jsoup" % "jsoup" % "1.13.1",
     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3",
@@ -23,6 +24,12 @@ lazy val root = project
         "IRC_USER" -> sys.env("IRC_USER"),
         "IRC_PASS" -> sys.env("IRC_PASS"),
         "IRC_HOST" -> sys.env("IRC_HOST"),
-        "IRC_CHANNELS" -> sys.env("IRC_CHANNELS")
+        "IRC_CHANNELS" -> sys.env("IRC_CHANNELS"),
+        "DARK_SKY_API_KEY" -> sys.env("DARK_SKY_API_KEY")
+      ),
+    Test / fork := true,
+    Test / envVars :=
+      Map(
+        "DARK_SKY_API_KEY" -> "alligator3"
       )
   )

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -31,7 +31,8 @@ object Producer:
       Html,
       Substitute,
       Count,
-      Stock
+      Stock,
+      Weather(sys.env("DARK_SKY_API_KEY"))
     )
 
   def init(): RIO[Env, Iterable[Unit]] =

--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -1,0 +1,114 @@
+package sectery.producers
+
+import java.net.URLEncoder
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.json4s.native.JsonMethods._
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+import sectery.Http
+import sectery.Producer
+import sectery.Response
+import sectery.Rx
+import sectery.Tx
+import zio.clock.Clock
+import zio.Has
+import zio.URIO
+import zio.ZIO
+
+class Weather(darkSkyApiKey: String) extends Producer:
+
+  case class Place(displayName: String, lat: Double, lon: Double)
+  case class Wx(temperature: Double, humidity: Double, wind: Double, gusts: Double, uvIndex: Int)
+
+  private def findPlace(q: String): URIO[Http.Http, Option[Place]] =
+    Http.request(
+      method = "GET",
+      url = s"""https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${URLEncoder.encode(q, "UTF-8")}""",
+      headers = Map("User-Agent" -> "bot", "Accept" -> "application/json"),
+      body = None
+    )
+    .flatMap {
+      case Response(200, _, body) =>
+        ZIO.effect {
+          val json = parse(body)
+          ( 
+            json(0) \ "display_name",
+            json(0) \ "lat",
+            json(0) \ "lon"
+          ) match
+            case (JString(displayName), JString(lat), JString(lon)) =>
+              Some(Place(displayName = displayName, lat = lat.toDouble, lon = lon.toDouble))
+            case _ =>
+              None
+        }
+    }
+    .catchAll { e =>
+      LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
+      ZIO.effectTotal(None)
+    }
+
+  private def findWx(lat: Double, lon: Double): URIO[Http.Http, Option[Wx]] =
+    Http.request(
+      method = "GET",
+      url = s"""https://api.darksky.net/forecast/${darkSkyApiKey}/${lat},${lon}""",
+      headers = Map("User-Agent" -> "bot", "Accept" -> "application/json"),
+      body = None
+    )
+    .flatMap {
+      case Response(200, _, body) =>
+        ZIO.effect {
+          val json = parse(body)
+          ( 
+            json \ "currently" \ "temperature",
+            json \ "currently" \ "humidity",
+            json \ "currently" \ "windSpeed",
+            json \ "currently" \ "windGust",
+            json \ "currently" \ "uvIndex"
+          ) match
+            case (
+              JDouble(temperature),
+              JDouble(humidity),
+              JDouble(windSpeed),
+              JDouble(windGust),
+              JInt(uvIndex)
+            ) =>
+              Some(
+                Wx(
+                  temperature = temperature,
+                  humidity = humidity,
+                  wind = windSpeed,
+                  gusts = windGust,
+                  uvIndex = uvIndex.toInt
+                )
+              )
+            case _ =>
+              None
+        }
+    }
+    .catchAll { e =>
+      LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
+      ZIO.effectTotal(None)
+    }
+
+  private val wx = """^@wx\s+(.+)\s*$""".r
+  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+    m match
+      case Rx(c, _, wx(q)) =>
+        findPlace(q).flatMap {
+          case Some(p@Place(_, lat, lon)) =>
+            findWx(lat, lon) flatMap {
+              case Some(wx) =>
+                ZIO.succeed(Some(Tx(c, f"${p.displayName}: temperature ${wx.temperature}%.0f°, humidity ${wx.humidity}%.1f%%, wind ${wx.wind}%.1f mph, UV index ${wx.uvIndex}")))
+              case None =>
+                ZIO.succeed(List(Tx(c, s"I can't find the weather for ${q}.")))
+            }
+          case None =>
+            ZIO.succeed(List(Tx(c, s"I have no idea where ${q} is.")))
+        }
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/test/scala/sectery/producers/WeatherSpec.scala
+++ b/src/test/scala/sectery/producers/WeatherSpec.scala
@@ -1,0 +1,119 @@
+package sectery.producers
+
+import sectery._
+import zio._
+import zio.duration._
+import zio.Inject._
+import zio.test._
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestClock
+import zio.test.TestAspect._
+
+object WeatherSpec extends DefaultRunnableSpec:
+
+  val http: ULayer[Has[Http.Service]] =
+    ZLayer.succeed {
+      new Http.Service:
+        def request(
+          method: String,
+          url: String,
+          headers: Map[String, String],
+          body: Option[String]
+        ): UIO[Response] =
+          url match
+            case "https://nominatim.openstreetmap.org/search?format=json&limit=1&q=90210" =>
+              ZIO.effectTotal {
+                Response(
+                  status = 200,
+                  headers = Map.empty,
+                  body = """|[
+                            |  {
+                            |    "place_id": 260840887,
+                            |    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+                            |    "boundingbox": [
+                            |      "33.935082673098",
+                            |      "34.255082673098",
+                            |      "-118.55932247265",
+                            |      "-118.23932247265"
+                            |    ],
+                            |    "lat": "34.095082673097856",
+                            |    "lon": "-118.39932247264568",
+                            |    "display_name": "Beverly Hills, California, 90210, United States",
+                            |    "class": "place",
+                            |    "type": "postcode",
+                            |    "importance": 0.33499999999999996
+                            |  }
+                            |]
+                            |""".stripMargin
+                )
+              }
+            case "https://api.darksky.net/forecast/alligator3/34.095082673097856,-118.39932247264568" =>
+              ZIO.effectTotal {
+                Response(
+                  status = 200,
+                  headers = Map.empty,
+                  body = """|{
+                            |  "latitude": 34.095082673097856,
+                            |  "longitude": -118.39932247264568,
+                            |  "timezone": "America/Los_Angeles",
+                            |  "currently": {
+                            |    "time": 1622806677,
+                            |    "summary": "Clear",
+                            |    "icon": "clear-night",
+                            |    "nearestStormDistance": 11,
+                            |    "nearestStormBearing": 42,
+                            |    "precipIntensity": 0,
+                            |    "precipProbability": 0,
+                            |    "temperature": 55.99,
+                            |    "apparentTemperature": 55.99,
+                            |    "dewPoint": 55.11,
+                            |    "humidity": 0.97,
+                            |    "pressure": 1013.2,
+                            |    "windSpeed": 1.87,
+                            |    "windGust": 2.42,
+                            |    "windBearing": 257,
+                            |    "cloudCover": 0.2,
+                            |    "uvIndex": 0,
+                            |    "visibility": 10,
+                            |    "ozone": 326.2
+                            |  },
+                            |  "minutely": {
+                            |  },
+                            |  "hourly": {
+                            |  },
+                            |  "daily": {
+                            |  },
+                            |  "alerts": [
+                            |  ],
+                            |  "flags": {
+                            |  },
+                            |  "offset": -7
+                            |}
+                            |""".stripMargin
+                )
+              }
+            case _ =>
+              ZIO.effectTotal {
+                Response(
+                  status = 404,
+                  headers = Map.empty,
+                  body = ""
+                )
+              }
+    }
+
+  override def spec =
+    suite(getClass().getName())(
+      testM("@wx produces weather") {
+        for
+          sent   <- ZQueue.unbounded[Tx]
+          fh      = sys.env.get("TEST_FINNHUB_LIVE") match
+                      case Some("true") => Finnhub.live
+                      case _ => TestFinnhub()
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(fh, TestDb(), http)
+          _      <- inbox.offer(Rx("#foo", "bar", "@wx 90210"))
+          _      <- TestClock.adjust(1.seconds)
+          ms     <- sent.takeAll
+        yield assert(ms)(equalTo(List(Tx("#foo", "Beverly Hills, California, 90210, United States: temperature 56°, humidity 1.0%, wind 1.9 mph, UV index 0"))))
+      } @@ timeout(2.seconds)
+    )


### PR DESCRIPTION
This adds support for `@wx <location>`, which gets the current weather
at the given location.

OpenStreetMap is used to search for the location, and DarkSky is used to
get weather by lat/lon.  Json4s is used for parsing JSON responses from
both.  DarkSky requires an API key, which must be set in the
`DARK_SKY_API_KEY` environment variable.