### PR TITLE
Add a rudimentary @help command to list commands

### DIFF
--- a/src/main/scala/sectery/producers/Count.scala
+++ b/src/main/scala/sectery/producers/Count.scala
@@ -11,6 +11,10 @@ import zio.URIO
 import zio.ZIO
 
 object Count extends Producer:
+
+  override def help(): Iterable[String] =
+    Some("@count")
+
   override def init(): RIO[Db.Db, Unit] =
     for
       _ <- Db.query { conn =>

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -13,7 +13,12 @@ import zio.URIO
 import zio.ZIO
 
 object Eval extends Producer:
+
   private val eval = """^@eval\s+(.+)\s*$""".r
+
+  override def help(): Iterable[String] =
+    Some("@eval")
+
   override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, eval(expr)) =>

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -19,6 +19,9 @@ object Html extends Producer:
 
   private val url = """.*(http[^\s]+).*""".r
 
+  override def help(): Iterable[String] =
+    None
+
   override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, url(url)) =>

--- a/src/main/scala/sectery/producers/Ping.scala
+++ b/src/main/scala/sectery/producers/Ping.scala
@@ -8,6 +8,10 @@ import zio.URIO
 import zio.ZIO
 
 object Ping extends Producer:
+
+  override def help(): Iterable[String] =
+    Some("@ping")
+
   override def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
     m match
       case Rx(c, _, "@ping") =>

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -14,7 +14,12 @@ import zio.Task
 import zio.ZIO
 
 object Stock extends Producer:
+
   private val stock = """^@stock\s+([^\s]+)\s*$""".r
+
+  override def help(): Iterable[String] =
+    Some("@stock")
+
   override def apply(m: Rx): URIO[Finnhub.Finnhub, Iterable[Tx]] =
     m match
       case Rx(c, _, stock(symbol)) =>

--- a/src/main/scala/sectery/producers/Substitute.scala
+++ b/src/main/scala/sectery/producers/Substitute.scala
@@ -19,6 +19,9 @@ object Substitute extends Producer:
 
   private val sub = """s\/(.*)\/(.*)\/""".r
 
+  override def help(): Iterable[String] =
+    None
+
   override def init(): RIO[Db.Db, Unit] =
     for
       _ <- Db.query { conn =>

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -12,6 +12,10 @@ import zio.URIO
 import zio.ZIO
 
 object Time extends Producer:
+
+  override def help(): Iterable[String] =
+    Some("@time")
+
   override def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
     m match
       case Rx(c, _, "@time") =>

--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -96,6 +96,10 @@ class Weather(darkSkyApiKey: String) extends Producer:
     }
 
   private val wx = """^@wx\s+(.+)\s*$""".r
+
+  override def help(): Iterable[String] =
+    Some("@wx")
+
   override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, wx(q)) =>

--- a/src/test/scala/sectery/producers/Help.scala
+++ b/src/test/scala/sectery/producers/Help.scala
@@ -1,0 +1,25 @@
+package sectery.producers
+
+import sectery._
+import zio._
+import zio.duration._
+import zio.Inject._
+import zio.test._
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestClock
+import zio.test.TestAspect._
+
+object HelpSpec extends DefaultRunnableSpec:
+  override def spec =
+    suite(getClass().getName())(
+    testM("@help produces help") {
+      for
+        sent   <- ZQueue.unbounded[Tx]
+        inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), TestHttp())
+        _      <- inbox.offer(Rx("#foo", "bar", "@help"))
+        _      <- TestClock.adjust(1.seconds)
+        ms     <- sent.takeAll
+      yield
+        assert(ms)(equalTo(List(Tx("#foo", "Available commands: @count, @eval, @ping, @stock, @time, @wx"))))
+      } @@ timeout(2.seconds)
+    )


### PR DESCRIPTION
This updates the `Producer` trait to include a list of `@commands` that
it responds to, which are reported when the user types `@help`.