### PR TITLE
Expand @help to include usage information

### DIFF
--- a/src/main/scala/sectery/producers/Count.scala
+++ b/src/main/scala/sectery/producers/Count.scala
@@ -2,6 +2,7 @@ package sectery.producers
 
 import org.slf4j.LoggerFactory
 import sectery.Db
+import sectery.Info
 import sectery.Producer
 import sectery.Rx
 import sectery.Tx
@@ -12,8 +13,8 @@ import zio.ZIO
 
 object Count extends Producer:
 
-  override def help(): Iterable[String] =
-    Some("@count")
+  override def help(): Iterable[Info] =
+    Some(Info("@count", "@count"))
 
   override def init(): RIO[Db.Db, Unit] =
     for

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -3,6 +3,7 @@ package sectery.producers
 import org.slf4j.LoggerFactory
 import java.net.URLEncoder
 import sectery.Http
+import sectery.Info
 import sectery.Producer
 import sectery.Response
 import sectery.Rx
@@ -16,8 +17,8 @@ object Eval extends Producer:
 
   private val eval = """^@eval\s+(.+)\s*$""".r
 
-  override def help(): Iterable[String] =
-    Some("@eval")
+  override def help(): Iterable[Info] =
+    Some(Info("@eval", "@eval <expression>, e.g. @eval 6 * 7"))
 
   override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
     m match

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -6,6 +6,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import scala.collection.JavaConverters._
 import sectery.Http
+import sectery.Info
 import sectery.Producer
 import sectery.Response
 import sectery.Rx
@@ -19,7 +20,7 @@ object Html extends Producer:
 
   private val url = """.*(http[^\s]+).*""".r
 
-  override def help(): Iterable[String] =
+  override def help(): Iterable[Info] =
     None
 
   override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =

--- a/src/main/scala/sectery/producers/Ping.scala
+++ b/src/main/scala/sectery/producers/Ping.scala
@@ -1,5 +1,6 @@
 package sectery.producers
 
+import sectery.Info
 import sectery.Producer
 import sectery.Rx
 import sectery.Tx
@@ -9,8 +10,8 @@ import zio.ZIO
 
 object Ping extends Producer:
 
-  override def help(): Iterable[String] =
-    Some("@ping")
+  override def help(): Iterable[Info] =
+    Some(Info("@ping", "@ping"))
 
   override def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
     m match

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -2,6 +2,7 @@ package sectery.producers
 
 import org.slf4j.LoggerFactory
 import sectery.Finnhub
+import sectery.Info
 import sectery.Producer
 import sectery.Response
 import sectery.Rx
@@ -17,8 +18,8 @@ object Stock extends Producer:
 
   private val stock = """^@stock\s+([^\s]+)\s*$""".r
 
-  override def help(): Iterable[String] =
-    Some("@stock")
+  override def help(): Iterable[Info] =
+    Some(Info("@stock", "@stock <symbol>, e.g. @stock GME"))
 
   override def apply(m: Rx): URIO[Finnhub.Finnhub, Iterable[Tx]] =
     m match

--- a/src/main/scala/sectery/producers/Substitute.scala
+++ b/src/main/scala/sectery/producers/Substitute.scala
@@ -3,6 +3,7 @@ package sectery.producers
 import org.slf4j.LoggerFactory
 import scala.util.matching.Regex
 import sectery.Db
+import sectery.Info
 import sectery.Producer
 import sectery.Response
 import sectery.Rx
@@ -19,8 +20,8 @@ object Substitute extends Producer:
 
   private val sub = """s\/(.*)\/(.*)\/""".r
 
-  override def help(): Iterable[String] =
-    None
+  override def help(): Iterable[Info] =
+    Some(Info("s///", "s/find/replace/"))
 
   override def init(): RIO[Db.Db, Unit] =
     for

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat
 import java.util.concurrent.TimeUnit
 import java.util.Date
 import java.util.TimeZone
+import sectery.Info
 import sectery.Producer
 import sectery.Rx
 import sectery.Tx
@@ -13,8 +14,8 @@ import zio.ZIO
 
 object Time extends Producer:
 
-  override def help(): Iterable[String] =
-    Some("@time")
+  override def help(): Iterable[Info] =
+    Some(Info("@time", "@time"))
 
   override def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
     m match

--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -11,6 +11,7 @@ import org.jsoup.nodes.Element
 import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters._
 import sectery.Http
+import sectery.Info
 import sectery.Producer
 import sectery.Response
 import sectery.Rx
@@ -97,8 +98,8 @@ class Weather(darkSkyApiKey: String) extends Producer:
 
   private val wx = """^@wx\s+(.+)\s*$""".r
 
-  override def help(): Iterable[String] =
-    Some("@wx")
+  override def help(): Iterable[Info] =
+    Some(Info("@wx", "@wx <location>, e.g. @wx san francisco"))
 
   override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
     m match


### PR DESCRIPTION
This expands the `@help` registration mechanism to take both a name and
a message about usage info.  Users can still get the list of supported
patterns via `@help`, but can now also get specific usage information
via `@help @foo`.