### PR TITLE
Add support for @btc

### DIFF
--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -72,7 +72,8 @@ object Producer:
         Substitute,
         Count,
         Stock,
-        Weather(sys.env("DARK_SKY_API_KEY"))
+        Weather(sys.env("DARK_SKY_API_KEY")),
+        Btc
       )
     )
 

--- a/src/main/scala/sectery/producers/Btc.scala
+++ b/src/main/scala/sectery/producers/Btc.scala
@@ -2,6 +2,7 @@ package sectery.producers
 
 import java.net.URLEncoder
 import java.text.NumberFormat
+import java.util.Locale
 import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.MonadicJValue.jvalueToMonadic
@@ -52,7 +53,7 @@ object Btc extends Producer:
       case Rx(c, _, "@btc") =>
         findRate.flatMap {
           case Some(rate) =>
-            ZIO.succeed(Some(Tx(c, s"${NumberFormat.getCurrencyInstance.format(rate)}")))
+            ZIO.succeed(Some(Tx(c, s"${NumberFormat.getCurrencyInstance(Locale.US).format(rate)}")))
           case None =>
             ZIO.effectTotal(None)
         }

--- a/src/main/scala/sectery/producers/Btc.scala
+++ b/src/main/scala/sectery/producers/Btc.scala
@@ -1,0 +1,60 @@
+package sectery.producers
+
+import java.net.URLEncoder
+import java.text.NumberFormat
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.json4s.native.JsonMethods._
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+import sectery.Http
+import sectery.Info
+import sectery.Producer
+import sectery.Response
+import sectery.Rx
+import sectery.Tx
+import zio.clock.Clock
+import zio.Has
+import zio.URIO
+import zio.ZIO
+
+object Btc extends Producer:
+
+  private val findRate: URIO[Http.Http, Option[Double]] =
+    Http.request(
+      method = "GET",
+      url = "https://api.coindesk.com/v1/bpi/currentprice.json",
+      headers = Map("User-Agent" -> "bot"),
+      body = None
+    )
+    .flatMap {
+      case Response(200, _, body) =>
+        ZIO.effect {
+          val json = parse(body)
+          json \ "bpi" \ "USD" \ "rate_float" match
+            case JDouble(rate) =>
+              Some(rate)
+            case _ =>
+              None
+        }
+    }
+    .catchAll { e =>
+      LoggerFactory.getLogger(this.getClass()).error("caught exception", e)
+      ZIO.effectTotal(None)
+    }
+
+  override def help(): Iterable[Info] =
+    Some(Info("@btc", "@btc"))
+
+  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+    m match
+      case Rx(c, _, "@btc") =>
+        findRate.flatMap {
+          case Some(rate) =>
+            ZIO.succeed(Some(Tx(c, s"${NumberFormat.getCurrencyInstance.format(rate)}")))
+          case None =>
+            ZIO.effectTotal(None)
+        }
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/test/scala/sectery/producers/BtcSpec.scala
+++ b/src/test/scala/sectery/producers/BtcSpec.scala
@@ -1,0 +1,64 @@
+package sectery.producers
+
+import sectery._
+import zio._
+import zio.duration._
+import zio.Inject._
+import zio.test._
+import zio.test.Assertion.equalTo
+import zio.test.environment.TestClock
+import zio.test.TestAspect._
+
+object BtcSpec extends DefaultRunnableSpec:
+
+  val http: ULayer[Has[Http.Service]] =
+    ZLayer.succeed {
+      new Http.Service:
+        def request(
+          method: String,
+          url: String,
+          headers: Map[String, String],
+          body: Option[String]
+        ): UIO[Response] =
+          url match
+            case "https://api.coindesk.com/v1/bpi/currentprice.json" =>
+              ZIO.effectTotal {
+                Response(
+                  status = 200,
+                  headers = Map.empty,
+                  body = """|{
+                            |  "time": {
+                            |  },
+                            |  "disclaimer": "",
+                            |  "chartName": "Bitcoin",
+                            |  "bpi": {
+                            |    "USD": {
+                            |      "code": "USD",
+                            |      "symbol": "&#36;",
+                            |      "rate": "35,929.0133",
+                            |      "description": "United States Dollar",
+                            |      "rate_float": 35929.0133
+                            |    },
+                            |    "GBP": {
+                            |    },
+                            |    "EUR": {
+                            |    }
+                            |  }
+                            |}
+                            |""".stripMargin
+                )
+              }
+    }
+
+  override def spec =
+    suite(getClass().getName())(
+      testM("@btc produces rate") {
+        for
+          sent   <- ZQueue.unbounded[Tx]
+          inbox  <- MessageQueues.loop(new MessageLogger(sent)).inject(TestFinnhub(), TestDb(), http)
+          _      <- inbox.offer(Rx("#foo", "bar", "@btc"))
+          _      <- TestClock.adjust(1.seconds)
+          ms     <- sent.takeAll
+        yield assert(ms)(equalTo(List(Tx("#foo", "$35,929.01"))))
+      } @@ timeout(2.seconds)
+    )

--- a/src/test/scala/sectery/producers/HelpSpec.scala
+++ b/src/test/scala/sectery/producers/HelpSpec.scala
@@ -24,7 +24,7 @@ object HelpSpec extends DefaultRunnableSpec:
         ms     <- sent.takeAll
       yield
         assert(ms)(equalTo(List(
-          Tx("#foo", "@count, @eval, @ping, @stock, @time, @wx, s///"),
+          Tx("#foo", "@btc, @count, @eval, @ping, @stock, @time, @wx, s///"),
           Tx("#foo", "Usage: @wx <location>, e.g. @wx san francisco"),
           Tx("#foo", "Usage: @count"),
           Tx("#foo", "I don't know anything about @foo")


### PR DESCRIPTION
This introduces a simple CoinDesk API client, and a message producer
that responds to `@btc` with the current BTC rate in USD.

Fixes #174