### PR TITLE
Add sbt-scalafix and enable OrganizeImports

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,4 +8,4 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: sbt test scalafmtCheckAll
+    - run: sbt test scalafmtCheckAll "scalafixAll --check"

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,9 @@
+rules = [
+  OrganizeImports
+]
+
+OrganizeImports {
+  groups = [
+    "*"
+  ]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scala3Version = "3.0.0"
 val zioVersion = "1.0.9"
 
-val scalafixSettings =
+val enableScalafix =
   List(
     scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0",
     scalaVersion := "3.0.0",
@@ -10,7 +10,7 @@ val scalafixSettings =
     scalacOptions += "-Xlint:unused" // unsupported in Scala 3, but required by scalafix
   )
 
-inThisBuild(scalafixSettings)
+inThisBuild(enableScalafix)
 
 resolvers += "jitpack" at "https://jitpack.io/"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,7 @@
 val scala3Version = "3.0.0"
 val zioVersion = "1.0.9"
 
-resolvers += "jitpack" at "https://jitpack.io/"
-
-inThisBuild(
+val scalafixSettings =
   List(
     scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0",
     scalaVersion := "3.0.0",
@@ -11,8 +9,10 @@ inThisBuild(
     semanticdbVersion := scalafixSemanticdb.revision,
     scalacOptions += "-Xlint:unused" // unsupported in Scala 3, but required by scalafix
   )
-)
 
+inThisBuild(scalafixSettings)
+
+resolvers += "jitpack" at "https://jitpack.io/"
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,17 @@ val zioVersion = "1.0.9"
 
 resolvers += "jitpack" at "https://jitpack.io/"
 
+inThisBuild(
+  List(
+    scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0",
+    scalaVersion := "3.0.0",
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalacOptions += "-Xlint:unused" // unsupported in Scala 3, but required by scalafix
+  )
+)
+
+
 lazy val root = project
   .in(file("."))
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")

--- a/src/main/scala/sectery/Bot.scala
+++ b/src/main/scala/sectery/Bot.scala
@@ -1,12 +1,12 @@
 package sectery
 
-import org.pircbotx.cap.SASLCapHandler
 import javax.net.ssl.SSLSocketFactory
 import org.pircbotx.Configuration
-import org.pircbotx.hooks.events.MessageEvent
-import org.pircbotx.hooks.ListenerAdapter
-import org.pircbotx.hooks.types.GenericMessageEvent
 import org.pircbotx.PircBotX
+import org.pircbotx.cap.SASLCapHandler
+import org.pircbotx.hooks.ListenerAdapter
+import org.pircbotx.hooks.events.MessageEvent
+import org.pircbotx.hooks.types.GenericMessageEvent
 import scala.collection.JavaConverters._
 import zio.UIO
 import zio.ZIO

--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -1,7 +1,5 @@
 package sectery
 
-import zio.clock.Clock
-import zio.duration._
 import zio.Has
 import zio.Queue
 import zio.RIO
@@ -10,6 +8,8 @@ import zio.UIO
 import zio.URIO
 import zio.ZIO
 import zio.ZQueue
+import zio.clock.Clock
+import zio.duration._
 
 /** A message received from IRC.
   */

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -1,11 +1,11 @@
 package sectery
 
 import sectery.producers._
-import zio.clock.Clock
 import zio.RIO
 import zio.UIO
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 case class Info(name: String, usage: String)
 

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -2,12 +2,12 @@ package sectery
 
 import org.slf4j.LoggerFactory
 import zio.App
-import zio.clock.Clock
 import zio.ExitCode
 import zio.RIO
 import zio.URIO
 import zio.ZEnv
 import zio.ZIO
+import zio.clock.Clock
 
 object Sectery extends App:
 

--- a/src/main/scala/sectery/producers/Btc.scala
+++ b/src/main/scala/sectery/producers/Btc.scala
@@ -3,9 +3,9 @@ package sectery.producers
 import java.net.URLEncoder
 import java.text.NumberFormat
 import java.util.Locale
-import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.MonadicJValue.jvalueToMonadic
+import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters._
@@ -15,10 +15,10 @@ import sectery.Producer
 import sectery.Response
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.Has
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 object Btc extends Producer:
 

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -1,17 +1,17 @@
 package sectery.producers
 
-import org.slf4j.LoggerFactory
 import java.net.URLEncoder
+import org.slf4j.LoggerFactory
 import sectery.Http
 import sectery.Info
 import sectery.Producer
 import sectery.Response
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.Has
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 object Eval extends Producer:
 

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -1,9 +1,9 @@
 package sectery.producers
 
-import org.slf4j.LoggerFactory
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters._
 import sectery.Http
 import sectery.Info
@@ -11,10 +11,10 @@ import sectery.Producer
 import sectery.Response
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.Has
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 object Html extends Producer:
 

--- a/src/main/scala/sectery/producers/Ping.scala
+++ b/src/main/scala/sectery/producers/Ping.scala
@@ -4,9 +4,9 @@ import sectery.Info
 import sectery.Producer
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 object Ping extends Producer:
 

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -7,12 +7,12 @@ import sectery.Producer
 import sectery.Response
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.Has
-import zio.URIO
-import zio.UIO
 import zio.Task
+import zio.UIO
+import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 object Stock extends Producer:
 

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -1,16 +1,16 @@
 package sectery.producers
 
 import java.text.SimpleDateFormat
-import java.util.concurrent.TimeUnit
 import java.util.Date
 import java.util.TimeZone
+import java.util.concurrent.TimeUnit
 import sectery.Info
 import sectery.Producer
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 object Time extends Producer:
 

--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -1,9 +1,9 @@
 package sectery.producers
 
 import java.net.URLEncoder
-import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.MonadicJValue.jvalueToMonadic
+import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -16,10 +16,10 @@ import sectery.Producer
 import sectery.Response
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.Has
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 class Weather(darkSkyApiKey: String) extends Producer:
 

--- a/src/test/scala/sectery/producers/BtcSpec.scala
+++ b/src/test/scala/sectery/producers/BtcSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object BtcSpec extends DefaultRunnableSpec:
 

--- a/src/test/scala/sectery/producers/CountSpec.scala
+++ b/src/test/scala/sectery/producers/CountSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object CountSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/EvalSpec.scala
+++ b/src/test/scala/sectery/producers/EvalSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object EvalSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/HelpSpec.scala
+++ b/src/test/scala/sectery/producers/HelpSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object HelpSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/HtmlSpec.scala
+++ b/src/test/scala/sectery/producers/HtmlSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object HtmlSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/PingSpec.scala
+++ b/src/test/scala/sectery/producers/PingSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object PingSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/StockSpec.scala
+++ b/src/test/scala/sectery/producers/StockSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object StockSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/SubstituteSpec.scala
+++ b/src/test/scala/sectery/producers/SubstituteSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object SubstituteSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/TimeSpec.scala
+++ b/src/test/scala/sectery/producers/TimeSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object TimeSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/WeatherSpec.scala
+++ b/src/test/scala/sectery/producers/WeatherSpec.scala
@@ -1,13 +1,13 @@
 package sectery.producers
 
 import sectery._
+import zio.Inject._
 import zio._
 import zio.duration._
-import zio.Inject._
-import zio.test._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestClock
 import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
 
 object WeatherSpec extends DefaultRunnableSpec:
 


### PR DESCRIPTION
This adds [sbt-scalafix][0], [OrganizeImports][1], and a CI step to
check whether sources have had their imports organized.  This also
applies OrganizeImports, so that the CI check will pass.

[0]: https://scalacenter.github.io/scalafix/
[1]: https://github.com/liancheng/scalafix-organize-imports
