### PR TITLE
Add Air Quality Index to @wx

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,12 +36,14 @@ lazy val root = project
         "IRC_PASS" -> sys.env("IRC_PASS"),
         "IRC_HOST" -> sys.env("IRC_HOST"),
         "IRC_CHANNELS" -> sys.env("IRC_CHANNELS"),
+        "AIRNOW_API_KEY" -> sys.env("AIRNOW_API_KEY"),
         "DARK_SKY_API_KEY" -> sys.env("DARK_SKY_API_KEY"),
         "FINNHUB_API_TOKEN" -> sys.env("FINNHUB_API_TOKEN")
       ),
     Test / fork := true,
     Test / envVars :=
       Map(
+        "AIRNOW_API_KEY" -> "alligator3",
         "DARK_SKY_API_KEY" -> "alligator3",
         "FINNHUB_API_TOKEN" -> "alligator3"
       )

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -74,7 +74,10 @@ object Producer:
         Substitute,
         Count,
         Stock(sys.env("FINNHUB_API_TOKEN")),
-        Weather(sys.env("DARK_SKY_API_KEY")),
+        Weather(
+          darkSkyApiKey = sys.env("DARK_SKY_API_KEY"),
+          airNowApiKey = sys.env("AIRNOW_API_KEY")
+        ),
         Btc
       )
     )

--- a/src/test/scala/sectery/producers/WeatherSpec.scala
+++ b/src/test/scala/sectery/producers/WeatherSpec.scala
@@ -92,6 +92,46 @@ object WeatherSpec extends DefaultRunnableSpec:
                             |""".stripMargin
                 )
               }
+            case "https://www.airnowapi.org/aq/observation/latLong/current/?format=application/json&latitude=34.095082673097856&longitude=-118.39932247264568&distance=50&API_KEY=alligator3" =>
+              ZIO.effectTotal {
+                Response(
+                  status = 200,
+                  headers = Map.empty,
+                  body = """|[
+                            |  {
+                            |    "DateObserved": "2021-06-05 ",
+                            |    "HourObserved": 10,
+                            |    "LocalTimeZone": "PST",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "O3",
+                            |    "AQI": 22,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    }
+                            |  },
+                            |  {
+                            |    "DateObserved": "2021-06-05 ",
+                            |    "HourObserved": 10,
+                            |    "LocalTimeZone": "PST",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "PM2.5",
+                            |    "AQI": 32,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    }
+                            |  }
+                            |]
+                            |""".stripMargin
+                )
+              }
             case _ =>
               ZIO.effectTotal {
                 Response(
@@ -118,7 +158,7 @@ object WeatherSpec extends DefaultRunnableSpec:
             List(
               Tx(
                 "#foo",
-                "Beverly Hills, California, 90210, United States: temperature 56°, humidity 1.0%, wind 1.9 mph, UV index 0"
+                "Beverly Hills, California, 90210, United States: temperature 56°, humidity 1.0%, wind 1.9 mph, UV index 0, O3: 22/Good, PM2.5: 32/Good"
               )
             )
           )


### PR DESCRIPTION
This adds an AirNow API client to retrieve Air Quality Index info as
part of weather info produced via `@wx`.  The client is added as a new
`AirNow` object.  This also refactors the location and forecast
retrieval into the `OSM` and `DarkSky` objects.

Fixes #176