### PR TITLE
Use the AQI forecast in addition to observation

### DIFF
--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -1,9 +1,9 @@
 package sectery.producers
 
 import java.net.URLEncoder
-import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.MonadicJValue.jvalueToMonadic
+import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -16,10 +16,10 @@ import sectery.Producer
 import sectery.Response
 import sectery.Rx
 import sectery.Tx
-import zio.clock.Clock
 import zio.Has
 import zio.URIO
 import zio.ZIO
+import zio.clock.Clock
 
 object OSM:
 

--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -1,9 +1,9 @@
 package sectery.producers
 
 import java.net.URLEncoder
+import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.MonadicJValue.jvalueToMonadic
-import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -16,10 +16,10 @@ import sectery.Producer
 import sectery.Response
 import sectery.Rx
 import sectery.Tx
+import zio.clock.Clock
 import zio.Has
 import zio.URIO
 import zio.ZIO
-import zio.clock.Clock
 
 object OSM:
 
@@ -124,7 +124,7 @@ object DarkSky:
         ZIO.effectTotal(None)
       }
 
-object AirNow:
+object AirNowObservation:
 
   case class AqiParameter(name: String, value: Int, category: String)
   case class Aqi(parameters: List[AqiParameter])
@@ -177,12 +177,79 @@ object AirNow:
         ZIO.effectTotal(None)
       }
 
+object AirNowForecast:
+
+  case class AqiParameter(
+      name: String,
+      date: String,
+      value: Int,
+      category: String
+  )
+  case class Aqi(parameters: List[AqiParameter])
+
+  private def parseAqiParameter(v: JValue): Option[AqiParameter] =
+    (
+      v \ "DateForecast",
+      v \ "ParameterName",
+      v \ "AQI",
+      v \ "Category" \ "Name"
+    ) match
+      case (
+            JString(date),
+            JString(name),
+            JInt(value),
+            JString(category)
+          ) =>
+        Some(
+          AqiParameter(
+            name = name,
+            date = date,
+            value = value.toInt,
+            category = category
+          )
+        )
+      case _ =>
+        None
+
+  private def parseAqi(v: JValue): Option[Aqi] =
+    v match
+      case JArray(xs) =>
+        Some(Aqi(xs.flatMap(parseAqiParameter)))
+      case _ =>
+        None
+
+  def findAqi(
+      apiKey: String,
+      lat: Double,
+      lon: Double
+  ): URIO[Http.Http, Option[Aqi]] =
+    Http
+      .request(
+        method = "GET",
+        url =
+          s"""https://www.airnowapi.org/aq/forecast/latLong/?format=application/json&latitude=${lat}&longitude=${lon}&distance=50&API_KEY=${apiKey}""",
+        headers =
+          Map("User-Agent" -> "bot", "Accept" -> "application/json"),
+        body = None
+      )
+      .flatMap { case Response(200, _, body) =>
+        ZIO.effect(parseAqi(parse(body)))
+      }
+      .catchAll { e =>
+        LoggerFactory
+          .getLogger(this.getClass())
+          .error("caught exception", e)
+        ZIO.effectTotal(None)
+      }
+
 class Weather(darkSkyApiKey: String, airNowApiKey: String)
     extends Producer:
 
+  case class AqiParameter(name: String, value: Int, category: String)
+
   case class Wx(
       forecast: DarkSky.Forecast,
-      aqi: AirNow.Aqi
+      aqi: List[AqiParameter]
   )
 
   private def findWx(
@@ -195,15 +262,44 @@ class Weather(darkSkyApiKey: String, airNowApiKey: String)
         lat = lat,
         lon = lon
       )
-      aqiO <- AirNow.findAqi(
+      aqiObservationO <- AirNowObservation.findAqi(
+        apiKey = airNowApiKey,
+        lat = lat,
+        lon = lon
+      )
+      aqiForecastO <- AirNowForecast.findAqi(
         apiKey = airNowApiKey,
         lat = lat,
         lon = lon
       )
     yield for
       forecast <- forecastO
-      aqi <- aqiO
-    yield Wx(forecast = forecast, aqi = aqi)
+      aqiObservation <- aqiObservationO
+      aqiForecast <- aqiForecastO
+    yield
+      var aqiMap: Map[String, AqiParameter] = Map.empty
+      aqiObservation.parameters.foreach { case p =>
+        if (!aqiMap.contains(p.name)) {
+          aqiMap = aqiMap + (p.name -> AqiParameter(
+            name = p.name,
+            value = p.value,
+            category = p.category
+          ))
+        }
+      }
+      aqiForecast.parameters.sortBy(_.date).foreach { case p =>
+        if (!aqiMap.contains(p.name)) {
+          aqiMap = aqiMap + (p.name -> AqiParameter(
+            name = p.name,
+            value = p.value,
+            category = p.category
+          ))
+        }
+      }
+      Wx(
+        forecast = forecast,
+        aqi = aqiMap.values.toList
+      )
 
   private val wx = """^@wx\s+(.+)\s*$""".r
 
@@ -227,7 +323,7 @@ class Weather(darkSkyApiKey: String, airNowApiKey: String)
                           f"humidity ${wx.forecast.humidity}%.1f%%",
                           f"wind ${wx.forecast.wind}%.1f mph",
                           f"UV index ${wx.forecast.uvIndex}"
-                        ) ++ wx.aqi.parameters.map(p =>
+                        ) ++ wx.aqi.map(p =>
                           s"${p.name}: ${p.value}/${p.category}"
                         )
                       ).mkString(", ")

--- a/src/test/scala/sectery/producers/WeatherSpec.scala
+++ b/src/test/scala/sectery/producers/WeatherSpec.scala
@@ -132,6 +132,112 @@ object WeatherSpec extends DefaultRunnableSpec:
                             |""".stripMargin
                 )
               }
+            case s"""https://www.airnowapi.org/aq/forecast/latLong/?format=application/json&latitude=34.095082673097856&longitude=-118.39932247264568&distance=50&API_KEY=alligator3""" =>
+              ZIO.effectTotal {
+                Response(
+                  status = 200,
+                  headers = Map.empty,
+                  body = """|[
+                            |  {
+                            |    "DateIssue": "2021-06-11 ",
+                            |    "DateForecast": "2021-06-12 ",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "O3",
+                            |    "AQI": 22,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    },
+                            |    "ActionDay": false,
+                            |    "Discussion": "..."
+                            |  },
+                            |  {
+                            |    "DateIssue": "2021-06-11 ",
+                            |    "DateForecast": "2021-06-12 ",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "PM2.5",
+                            |    "AQI": 32,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    },
+                            |    "ActionDay": false,
+                            |    "Discussion": "..."
+                            |  },
+                            |  {
+                            |    "DateIssue": "2021-06-11 ",
+                            |    "DateForecast": "2021-06-12 ",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "PM10",
+                            |    "AQI": 33,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    },
+                            |    "ActionDay": false,
+                            |    "Discussion": "..."
+                            |  },
+                            |  {
+                            |    "DateIssue": "2021-06-11 ",
+                            |    "DateForecast": "2021-06-13 ",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "O3",
+                            |    "AQI": 23,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    },
+                            |    "ActionDay": false,
+                            |    "Discussion": "..."
+                            |  },
+                            |  {
+                            |    "DateIssue": "2021-06-11 ",
+                            |    "DateForecast": "2021-06-13 ",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "PM2.5",
+                            |    "AQI": 33,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    },
+                            |    "ActionDay": false,
+                            |    "Discussion": "..."
+                            |  },
+                            |  {
+                            |    "DateIssue": "2021-06-11 ",
+                            |    "DateForecast": "2021-06-13 ",
+                            |    "ReportingArea": "SW Coastal LA",
+                            |    "StateCode": "CA",
+                            |    "Latitude": 33.9541,
+                            |    "Longitude": -118.4302,
+                            |    "ParameterName": "PM10",
+                            |    "AQI": 34,
+                            |    "Category": {
+                            |      "Number": 1,
+                            |      "Name": "Good"
+                            |    },
+                            |    "ActionDay": false,
+                            |    "Discussion": "..."
+                            |  }
+                            |]
+                            |""".stripMargin
+                )
+              }
             case _ =>
               ZIO.effectTotal {
                 Response(
@@ -158,7 +264,7 @@ object WeatherSpec extends DefaultRunnableSpec:
             List(
               Tx(
                 "#foo",
-                "Beverly Hills, California, 90210, United States: temperature 56°, humidity 1.0%, wind 1.9 mph, UV index 0, O3: 22/Good, PM2.5: 32/Good"
+                "Beverly Hills, California, 90210, United States: temperature 56°, humidity 1.0%, wind 1.9 mph, UV index 0, O3: 22/Good, PM2.5: 32/Good, PM10: 33/Good"
               )
             )
           )


### PR DESCRIPTION
For certain locations, the AQI current observation doesn't always return
an empty array.  For those same locations, the AQI forecast does
sometimes return something usable.

This changes the AQI retrieval process to include both the current
observation and the forecast, combining the first values found from each
to produce the final result.