### PR TITLE
Include weather forecast in response to @wx

### DIFF
--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -67,6 +67,8 @@ object DarkSky:
 
   case class Forecast(
       temperature: Double,
+      temperatureHigh: Double,
+      temperatureLow: Double,
       humidity: Double,
       wind: Double,
       gusts: Double,
@@ -92,6 +94,8 @@ object DarkSky:
           val json = parse(body)
           (
             json \ "currently" \ "temperature",
+            (json \ "daily" \ "data")(0) \ "temperatureHigh",
+            (json \ "daily" \ "data")(0) \ "temperatureLow",
             json \ "currently" \ "humidity",
             json \ "currently" \ "windSpeed",
             json \ "currently" \ "windGust",
@@ -99,6 +103,8 @@ object DarkSky:
           ) match
             case (
                   JDouble(temperature),
+                  JDouble(temperatureHigh),
+                  JDouble(temperatureLow),
                   JDouble(humidity),
                   JDouble(windSpeed),
                   JDouble(windGust),
@@ -107,6 +113,8 @@ object DarkSky:
               Some(
                 Forecast(
                   temperature = temperature,
+                  temperatureHigh = temperatureHigh,
+                  temperatureLow = temperatureLow,
                   humidity = humidity,
                   wind = windSpeed,
                   gusts = windGust,
@@ -319,7 +327,7 @@ class Weather(darkSkyApiKey: String, airNowApiKey: String)
                       c,
                       (
                         List(
-                          f"${p.displayName}: temperature ${wx.forecast.temperature}%.0f°",
+                          f"${p.displayName}: temperature ${wx.forecast.temperature}%.0f° (low ${wx.forecast.temperatureLow}%.0f°, high ${wx.forecast.temperatureHigh}%.0f°)",
                           f"humidity ${wx.forecast.humidity}%.1f%%",
                           f"wind ${wx.forecast.wind}%.1f mph",
                           f"UV index ${wx.forecast.uvIndex}"

--- a/src/test/scala/sectery/producers/WeatherSpec.scala
+++ b/src/test/scala/sectery/producers/WeatherSpec.scala
@@ -82,6 +82,49 @@ object WeatherSpec extends DefaultRunnableSpec:
                             |  "hourly": {
                             |  },
                             |  "daily": {
+                            |    "data": [
+                            |      {
+                            |        "time": 1623394800,
+                            |        "summary": "Clear throughout the day.",
+                            |        "icon": "clear-day",
+                            |        "sunriseTime": 1623415440,
+                            |        "sunsetTime": 1623467220,
+                            |        "moonPhase": 0.05,
+                            |        "precipIntensity": 0.0004,
+                            |        "precipIntensityMax": 0.0037,
+                            |        "precipIntensityMaxTime": 1623455760,
+                            |        "precipProbability": 0.02,
+                            |        "precipType": "rain",
+                            |        "temperatureHigh": 69.08,
+                            |        "temperatureHighTime": 1623463020,
+                            |        "temperatureLow": 59.43,
+                            |        "temperatureLowTime": 1623496560,
+                            |        "apparentTemperatureHigh": 68.58,
+                            |        "apparentTemperatureHighTime": 1623463020,
+                            |        "apparentTemperatureLow": 59.92,
+                            |        "apparentTemperatureLowTime": 1623496560,
+                            |        "dewPoint": 53.74,
+                            |        "humidity": 0.69,
+                            |        "pressure": 1013.5,
+                            |        "windSpeed": 5.86,
+                            |        "windGust": 16.46,
+                            |        "windGustTime": 1623458580,
+                            |        "windBearing": 233,
+                            |        "cloudCover": 0.06,
+                            |        "uvIndex": 10,
+                            |        "uvIndexTime": 1623441180,
+                            |        "visibility": 10,
+                            |        "ozone": 305.4,
+                            |        "temperatureMin": 58.25,
+                            |        "temperatureMinTime": 1623414120,
+                            |        "temperatureMax": 69.08,
+                            |        "temperatureMaxTime": 1623463020,
+                            |        "apparentTemperatureMin": 58.74,
+                            |        "apparentTemperatureMinTime": 1623414120,
+                            |        "apparentTemperatureMax": 68.58,
+                            |        "apparentTemperatureMaxTime": 1623463020
+                            |      }
+                            |    ]
                             |  },
                             |  "alerts": [
                             |  ],
@@ -264,7 +307,7 @@ object WeatherSpec extends DefaultRunnableSpec:
             List(
               Tx(
                 "#foo",
-                "Beverly Hills, California, 90210, United States: temperature 56°, humidity 1.0%, wind 1.9 mph, UV index 0, O3: 22/Good, PM2.5: 32/Good, PM10: 33/Good"
+                "Beverly Hills, California, 90210, United States: temperature 56° (low 59°, high 69°), humidity 1.0%, wind 1.9 mph, UV index 0, O3: 22/Good, PM2.5: 32/Good, PM10: 33/Good"
               )
             )
           )


### PR DESCRIPTION
This updates the Dark Sky `/forecast` parser to include the first entry
in `daily.data`, pull out the low and high temperature forecast for the
day, and include them in the response to `@wx`.

Fixes #184