### PR TITLE
Move CoinDesk sample response to a .json file

### DIFF
--- a/src/test/resources/com/coindesk/api/v1/bpi/currentprice.json
+++ b/src/test/resources/com/coindesk/api/v1/bpi/currentprice.json
@@ -1,0 +1,32 @@
+{
+  "time": {
+    "updated": "Jun 14, 2021 11:36:00 UTC",
+    "updatedISO": "2021-06-14T11:36:00+00:00",
+    "updateduk": "Jun 14, 2021 at 12:36 BST"
+  },
+  "disclaimer": "This data was produced from the CoinDesk Bitcoin Price Index (USD). Non-USD currency data converted using hourly conversion rate from openexchangerates.org",
+  "chartName": "Bitcoin",
+  "bpi": {
+    "USD": {
+      "code": "USD",
+      "symbol": "&#36;",
+      "rate": "39,193.0277",
+      "description": "United States Dollar",
+      "rate_float": 39193.0277
+    },
+    "GBP": {
+      "code": "GBP",
+      "symbol": "&pound;",
+      "rate": "27,781.8209",
+      "description": "British Pound Sterling",
+      "rate_float": 27781.8209
+    },
+    "EUR": {
+      "code": "EUR",
+      "symbol": "&euro;",
+      "rate": "32,333.3072",
+      "description": "Euro",
+      "rate_float": 32333.3072
+    }
+  }
+}

--- a/src/test/scala/sectery/Resource.scala
+++ b/src/test/scala/sectery/Resource.scala
@@ -1,0 +1,9 @@
+package sectery
+
+import scala.io.Source
+
+object Resource:
+  def read(path: String): String =
+    Source
+      .fromInputStream(getClass().getResourceAsStream(path))
+      .mkString

--- a/src/test/scala/sectery/producers/BtcSpec.scala
+++ b/src/test/scala/sectery/producers/BtcSpec.scala
@@ -26,26 +26,9 @@ object BtcSpec extends DefaultRunnableSpec:
                 Response(
                   status = 200,
                   headers = Map.empty,
-                  body = """|{
-                            |  "time": {
-                            |  },
-                            |  "disclaimer": "",
-                            |  "chartName": "Bitcoin",
-                            |  "bpi": {
-                            |    "USD": {
-                            |      "code": "USD",
-                            |      "symbol": "&#36;",
-                            |      "rate": "35,929.0133",
-                            |      "description": "United States Dollar",
-                            |      "rate_float": 35929.0133
-                            |    },
-                            |    "GBP": {
-                            |    },
-                            |    "EUR": {
-                            |    }
-                            |  }
-                            |}
-                            |""".stripMargin
+                  body = Resource.read(
+                    "/com/coindesk/api/v1/bpi/currentprice.json"
+                  )
                 )
               }
     }
@@ -61,6 +44,6 @@ object BtcSpec extends DefaultRunnableSpec:
           _ <- inbox.offer(Rx("#foo", "bar", "@btc"))
           _ <- TestClock.adjust(1.seconds)
           ms <- sent.takeAll
-        yield assert(ms)(equalTo(List(Tx("#foo", "$35,929.01"))))
+        yield assert(ms)(equalTo(List(Tx("#foo", "$39,193.03"))))
       } @@ timeout(2.seconds)
     )


### PR DESCRIPTION
This tidies up the @btc test code by moving the big block of JSON from
the Scala source to a *.json* file under src/test/resources.  The
*.json* file includes the full response from the CoinDesk API, rather
than the truncated version in *BtcSpec.scala*, which makes for a more
accurate test and will be useful for future reference.

This also adds a utility to read in a string given a path on the
classpath.
