### PR TITLE
Configure continuous deployment to Heroku

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
+
 on: [push]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: deploy
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,14 @@
+name: deploy
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "sectery"
+          heroku_email: "james@earldouglas.com"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: target/universal/stage/bin/sectery

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ val enableScalafix =
 
 inThisBuild(enableScalafix)
 
+enablePlugins(JavaAppPackaging)
+
 resolvers += "jitpack" at "https://jitpack.io/" // needed for pircbotx
 
 lazy val root = project
@@ -20,7 +22,7 @@ lazy val root = project
     name := "sectery",
     scalaVersion := scala3Version,
     libraryDependencies += "org.json4s" %% "json4s-native-core" % "4.0.0",
-    libraryDependencies += "org.xerial" % "sqlite-jdbc" % "3.34.0",
+    libraryDependencies += "org.postgresql" % "postgresql" % "42.2.1",
     libraryDependencies += "org.jsoup" % "jsoup" % "1.13.1",
     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3",
     libraryDependencies += "com.github.pircbotx" % "pircbotx" % "2.2",
@@ -28,18 +30,9 @@ lazy val root = project
     libraryDependencies += "dev.zio" %% "zio" % zioVersion,
     libraryDependencies += "dev.zio" %% "zio-test" % zioVersion % "test",
     libraryDependencies += "dev.zio" %% "zio-test-sbt" % zioVersion % "test",
+    libraryDependencies += "org.xerial" % "sqlite-jdbc" % "3.34.0" % "test",
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     Compile / run / fork := true,
-    Compile / run / envVars :=
-      Map(
-        "IRC_USER" -> sys.env("IRC_USER"),
-        "IRC_PASS" -> sys.env("IRC_PASS"),
-        "IRC_HOST" -> sys.env("IRC_HOST"),
-        "IRC_CHANNELS" -> sys.env("IRC_CHANNELS"),
-        "AIRNOW_API_KEY" -> sys.env("AIRNOW_API_KEY"),
-        "DARK_SKY_API_KEY" -> sys.env("DARK_SKY_API_KEY"),
-        "FINNHUB_API_TOKEN" -> sys.env("FINNHUB_API_TOKEN")
-      ),
     Test / fork := true,
     Test / envVars :=
       Map(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="info">
+  <root level="warn">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/src/main/scala/sectery/Db.scala
+++ b/src/main/scala/sectery/Db.scala
@@ -1,5 +1,6 @@
 package sectery
 
+import java.net.URI
 import java.sql._
 import zio._
 
@@ -13,10 +14,15 @@ object Db:
   val live: ULayer[Has[Service]] =
     ZLayer.succeed {
       new Service:
-        Class.forName("org.sqlite.JDBC");
-        lazy val dbPath = sys.env("SECTERY_DB")
+        lazy val dbUri = new URI(sys.env("DATABASE_URL"))
+        lazy val username = dbUri.getUserInfo().split(":")(0)
+        lazy val password = dbUri.getUserInfo().split(":")(1)
+        lazy val dbUrl =
+          s"jdbc:postgresql://${dbUri.getHost()}:${dbUri.getPort()}${dbUri.getPath()}?sslmode=require"
+
         lazy val conn: Connection =
-          DriverManager.getConnection(s"jdbc:sqlite:${dbPath}")
+          DriverManager.getConnection(dbUrl, username, password)
+
         override def query[A](k: Connection => A): Task[A] =
           ZIO.effect(k(conn))
     }

--- a/src/main/scala/sectery/Db.scala
+++ b/src/main/scala/sectery/Db.scala
@@ -14,14 +14,20 @@ object Db:
   val live: ULayer[Has[Service]] =
     ZLayer.succeed {
       new Service:
-        lazy val dbUri = new URI(sys.env("DATABASE_URL"))
-        lazy val username = dbUri.getUserInfo().split(":")(0)
-        lazy val password = dbUri.getUserInfo().split(":")(1)
-        lazy val dbUrl =
-          s"jdbc:postgresql://${dbUri.getHost()}:${dbUri.getPort()}${dbUri.getPath()}?sslmode=require"
+        // this is lazy so that it doesn't get evaluated during testing
+        lazy val conn: Connection = {
 
-        lazy val conn: Connection =
+          // for info about the DATABASE_URL env var, see
+          // https://devcenter.heroku.com/articles/heroku-postgresql#connecting-in-java
+          val dbUri = new URI(sys.env("DATABASE_URL"))
+
+          val username = dbUri.getUserInfo().split(":")(0)
+          val password = dbUri.getUserInfo().split(":")(1)
+          val dbUrl =
+            s"jdbc:postgresql://${dbUri.getHost()}:${dbUri.getPort()}${dbUri.getPath()}?sslmode=require"
+
           DriverManager.getConnection(dbUrl, username, password)
+        }
 
         override def query[A](k: Connection => A): Task[A] =
           ZIO.effect(k(conn))

--- a/src/main/scala/sectery/producers/Substitute.scala
+++ b/src/main/scala/sectery/producers/Substitute.scala
@@ -1,5 +1,7 @@
 package sectery.producers
 
+import java.sql.{Date => SqlDate}
+import java.util.Date
 import org.slf4j.LoggerFactory
 import scala.util.matching.Regex
 import sectery.Db
@@ -32,7 +34,7 @@ object Substitute extends Producer:
              |  CHANNEL VARCHAR(256) NOT NULL,
              |  NICK VARCHAR(256) NOT NULL,
              |  MESSAGE TEXT NOT NULL,
-             |  MILLIS DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+             |  TIMESTAMP TIMESTAMP NOT NULL,
              |  PRIMARY KEY (CHANNEL, NICK)
              |)
              |""".stripMargin
@@ -53,7 +55,7 @@ object Substitute extends Producer:
                 """|SELECT NICK, MESSAGE
                    |FROM LAST_MESSAGE
                    |WHERE CHANNEL = ?
-                   |ORDER BY MILLIS DESC
+                   |ORDER BY TIMESTAMP DESC
                    |""".stripMargin
               val stmt = conn.prepareStatement(s)
               stmt.setString(1, channel)
@@ -96,11 +98,12 @@ object Substitute extends Producer:
             }
             newCount <- Db.query { conn =>
               val s =
-                "INSERT INTO LAST_MESSAGE (CHANNEL, NICK, MESSAGE) VALUES (?, ?, ?)"
+                "INSERT INTO LAST_MESSAGE (CHANNEL, NICK, MESSAGE, TIMESTAMP) VALUES (?, ?, ?, ?)"
               val stmt = conn.prepareStatement(s)
               stmt.setString(1, channel)
               stmt.setString(2, nick)
               stmt.setString(3, msg)
+              stmt.setDate(4, new SqlDate((new Date()).getTime()))
               stmt.executeUpdate
               stmt.close
             }


### PR DESCRIPTION
This makes a few changes to allow sectery to deploy to and run on
Heroku:

* Drop unused forked runtime environment variables, since these are
  inherited from the parent environment
* Change root log level from `info` to `warn` to limit volume and exposure
* Add support for Postgres, and use it for production
    * https://devcenter.heroku.com/articles/heroku-postgresql#connecting-in-java
* Use sbt-native-packager to package as a Java app, with scripts
  generated in *target/universal/stage/bin/*
* Configure as a `worker` Heroku process type
    * https://devcenter.heroku.com/articles/procfile#other-process-types
* Deploy to Heroku when changes are pushed to the `master` branch