### PR TITLE
Add support for looking up the current version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,13 @@ val enableScalafix =
 
 inThisBuild(enableScalafix)
 
-enablePlugins(JavaAppPackaging)
-
 resolvers += "jitpack" at "https://jitpack.io/" // needed for pircbotx
 
 lazy val root = project
   .in(file("."))
+  .enablePlugins(JavaAppPackaging)
+  .enablePlugins(GitVersioning)
+  .enablePlugins(BuildInfoPlugin)
   .settings(
     name := "sectery",
     scalaVersion := scala3Version,
@@ -39,5 +40,7 @@ lazy val root = project
         "AIRNOW_API_KEY" -> "alligator3",
         "DARK_SKY_API_KEY" -> "alligator3",
         "FINNHUB_API_TOKEN" -> "alligator3"
-      )
+      ),
+    buildInfoKeys := Seq[BuildInfoKey](version),
+    buildInfoPackage := "sectery"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -78,7 +78,8 @@ object Producer:
           darkSkyApiKey = sys.env("DARK_SKY_API_KEY"),
           airNowApiKey = sys.env("AIRNOW_API_KEY")
         ),
-        Btc
+        Btc,
+        Version
       )
     )
 

--- a/src/main/scala/sectery/producers/Version.scala
+++ b/src/main/scala/sectery/producers/Version.scala
@@ -1,0 +1,23 @@
+package sectery.producers
+
+import sectery.BuildInfo
+import sectery.Info
+import sectery.Producer
+import sectery.Rx
+import sectery.Tx
+import zio.UIO
+import zio.ZIO
+
+object Version extends Producer:
+
+  override def help(): Iterable[Info] =
+    Some(Info("@version", "@version"))
+
+  override def apply(m: Rx): UIO[Iterable[Tx]] =
+    m match
+      case Rx(channel, _, "@version") =>
+        ZIO.effectTotal(
+          Some(Tx(channel, s"${BuildInfo.version}"))
+        )
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/test/scala/sectery/producers/HelpSpec.scala
+++ b/src/test/scala/sectery/producers/HelpSpec.scala
@@ -29,7 +29,7 @@ object HelpSpec extends DefaultRunnableSpec:
             List(
               Tx(
                 "#foo",
-                "@btc, @count, @eval, @ping, @stock, @time, @wx, s///"
+                "@btc, @count, @eval, @ping, @stock, @time, @version, @wx, s///"
               ),
               Tx(
                 "#foo",

--- a/src/test/scala/sectery/producers/VersionSpec.scala
+++ b/src/test/scala/sectery/producers/VersionSpec.scala
@@ -1,0 +1,28 @@
+package sectery.producers
+
+import sectery._
+import zio.Inject._
+import zio._
+import zio.duration._
+import zio.test.Assertion.matchesRegex
+import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
+
+object VersionSpec extends DefaultRunnableSpec:
+  override def spec =
+    suite(getClass().getName())(
+      testM("@version produces version") {
+        for
+          sent <- ZQueue.unbounded[Tx]
+          inbox <- MessageQueues
+            .loop(new MessageLogger(sent))
+            .inject(TestDb(), TestHttp())
+          _ <- inbox.offer(Rx("#foo", "bar", "@version"))
+          _ <- TestClock.adjust(1.seconds)
+          m <- sent.take
+        yield assert(m.message)(
+          matchesRegex("^[0-9a-f]{40}(-SNAPSHOT)?$")
+        )
+      } @@ timeout(2.seconds)
+    )


### PR DESCRIPTION
This uses [sbt-git][1] to compute version information at build time and
[sbt-buildinfo][2] to make it available at compile time and runtime.
This also adds a new `Version` producer which uses these to respond to
`@version` messages with the current version of sectery.

[1]: https://github.com/sbt/sbt-git
[2]: https://github.com/sbt/sbt-buildinfo