### PR TITLE
Add a Zillow scraper to search for Zestimates

### DIFF
--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -79,7 +79,8 @@ object Producer:
           airNowApiKey = sys.env("AIRNOW_API_KEY")
         ),
         Btc,
-        Version
+        Version,
+        Zillow
       )
     )
 

--- a/src/main/scala/sectery/producers/Zillow.scala
+++ b/src/main/scala/sectery/producers/Zillow.scala
@@ -1,0 +1,64 @@
+package sectery.producers
+
+import org.jsoup.Jsoup
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+import sectery.Http
+import sectery.Info
+import sectery.Producer
+import sectery.Response
+import sectery.Rx
+import sectery.Tx
+import zio.UIO
+import zio.URIO
+import zio.ZIO
+
+object Zillow extends Producer:
+
+  private val zillow = """^@zillow\s+(.+)\s*$""".r
+
+  override def help(): Iterable[Info] =
+    Some(
+      Info(
+        "@zillow",
+        "@zillow <address>, e.g. @zillow 123 main st, smithville, tx"
+      )
+    )
+
+  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+    m match
+      case Rx(c, _, zillow(address)) =>
+        val addressEnc =
+          address
+            .replaceAll("[^a-zA-Z0-9]", " ")
+            .trim()
+            .replaceAll("\\s+", "-")
+        val url = s"https://www.zillow.com/homes/${addressEnc}_rb/"
+        Http
+          .request(
+            method = "GET",
+            url = url,
+            headers = Map("User-Agent" -> "bot"),
+            body = None
+          )
+          .map {
+            case Response(200, _, body) =>
+              Jsoup
+                .parse(body)
+                .select("input[id=Est.-selling-price-of-your-home]")
+                .asScala
+                .headOption
+                .map(_.attr("value"))
+                .map(value => Tx(c, s"Zestimate: $$${value}"))
+            case r =>
+              None
+          }
+          .catchAll { e =>
+            LoggerFactory
+              .getLogger(this.getClass())
+              .error("caught exception", e)
+            ZIO.effectTotal(None)
+          }
+          .map(_.toIterable)
+      case _ =>
+        ZIO.effectTotal(None)

--- a/src/test/scala/sectery/producers/HelpSpec.scala
+++ b/src/test/scala/sectery/producers/HelpSpec.scala
@@ -29,7 +29,7 @@ object HelpSpec extends DefaultRunnableSpec:
             List(
               Tx(
                 "#foo",
-                "@btc, @count, @eval, @ping, @stock, @time, @version, @wx, s///"
+                "@btc, @count, @eval, @ping, @stock, @time, @version, @wx, @zillow, s///"
               ),
               Tx(
                 "#foo",

--- a/src/test/scala/sectery/producers/ZillowSpec.scala
+++ b/src/test/scala/sectery/producers/ZillowSpec.scala
@@ -1,0 +1,56 @@
+package sectery.producers
+
+import sectery._
+import zio.Inject._
+import zio._
+import zio.duration._
+import zio.test.Assertion.equalTo
+import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
+
+object ZillowSpec extends DefaultRunnableSpec:
+  override def spec =
+    suite(getClass().getName())(
+      testM("@zillow produces zestimate") {
+        val http: ULayer[Has[Http.Service]] =
+          ZLayer.succeed {
+            new Http.Service:
+              def request(
+                  method: String,
+                  url: String,
+                  headers: Map[String, String],
+                  body: Option[String]
+              ): UIO[Response] =
+                url match
+                  case "https://www.zillow.com/homes/123-main-st-cityville-st_rb/" =>
+                    ZIO.effectTotal {
+                      Response(
+                        status = 200,
+                        headers = Map.empty,
+                        body =
+                          """<input id="Est.-selling-price-of-your-home" value="123,456"/>"""
+                      )
+                    }
+                  case _ =>
+                    ZIO.effectTotal {
+                      Response(
+                        status = 404,
+                        headers = Map.empty,
+                        body = ""
+                      )
+                    }
+          }
+        for
+          sent <- ZQueue.unbounded[Tx]
+          inbox <- MessageQueues
+            .loop(new MessageLogger(sent))
+            .inject(TestDb(), http)
+          _ <- inbox.offer(
+            Rx("#foo", "bar", "@zillow 123 main st., cityville, st")
+          )
+          _ <- TestClock.adjust(1.seconds)
+          m <- sent.take
+        yield assert(m)(equalTo(Tx("#foo", "Zestimate: $123,456")))
+      } @@ timeout(2.seconds)
+    )


### PR DESCRIPTION
This adds a new producer that responds to `@zillow <address>` by looking
up the address on Zillow and searching for the Zestimate for that
address.