### PR TITLE
Allow root log level config via env var

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,8 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="warn">
+  <variable name="LOG_LEVEL_ROOT" value="${LOG_LEVEL_ROOT:-WARN}" />
+  <root level="${LOG_LEVEL_ROOT}">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
This adds support for an optional `LOG_LEVEL_ROOT` environment variable
to set the root log level.  If absent, it defaults to `WARN`.