### PR TITLE
Include the unexpected response in the log message

### DIFF
--- a/src/main/scala/sectery/producers/Btc.scala
+++ b/src/main/scala/sectery/producers/Btc.scala
@@ -39,7 +39,7 @@ object Btc extends Producer:
             case r =>
               LoggerFactory
                 .getLogger(this.getClass())
-                .error("unexpected response", r)
+                .error(s"unexpected response: ${r}")
               None
         }
       }

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -38,7 +38,7 @@ object Eval extends Producer:
             case r =>
               LoggerFactory
                 .getLogger(this.getClass())
-                .error("unexpected response", r)
+                .error(s"unexpected response: ${r}")
               None
           }
           .catchAll { e =>

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -39,7 +39,7 @@ object Html extends Producer:
             case r =>
               LoggerFactory
                 .getLogger(this.getClass())
-                .error("unexpected response", r)
+                .error(s"unexpected response: ${r}")
               None
           }
           .catchAll { e =>

--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -62,7 +62,7 @@ object OSM:
             case r =>
               LoggerFactory
                 .getLogger(this.getClass())
-                .error("unexpected response", r)
+                .error(s"unexpected response: ${r}")
               None
         }
       }

--- a/src/main/scala/sectery/producers/Zillow.scala
+++ b/src/main/scala/sectery/producers/Zillow.scala
@@ -55,7 +55,7 @@ object Zillow extends Producer:
             case r =>
               LoggerFactory
                 .getLogger(this.getClass())
-                .error("unexpected response", r)
+                .error(s"unexpected response: ${r}")
               None
           }
           .catchAll { e =>


### PR DESCRIPTION
This is a follow-up to #198 to make sure that the response itself is
included in the log message.