### PR TITLE
Switch HTML parser to look for the title

### DIFF
--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -53,10 +53,10 @@ object Html extends Producer:
       case _ =>
         ZIO.effectTotal(None)
 
-  def getTitle(doc: Document): Option[String] =
+  private def nonEmpty(x: String): Option[String] =
+    Option(x).map(_.trim).filter(_.length > 0)
 
-    def nonEmpty(x: String): Option[String] =
-      Option(x).map(_.trim).filter(_.length > 0)
+  def getTitle(doc: Document): Option[String] =
 
     val elements: List[Element] =
       doc.select("title").asScala.toList ++
@@ -67,18 +67,15 @@ object Html extends Producer:
         doc.select("meta[name=twitter:title]").asScala.toList ++
         doc.select("meta[property=twitter:title]").asScala.toList
 
-    val descriptions: List[String] =
+    val titles: List[String] =
       elements.map(_.attr("content"))
 
-    (descriptions :+ doc.title())
+    (titles :+ doc.title())
       .flatMap(nonEmpty)
       .map(_.replaceAll("[\\r\\n]", " ").replaceAll("\\s+", " "))
       .headOption
 
   def getDescription(doc: Document): Option[String] =
-
-    def nonEmpty(x: String): Option[String] =
-      Option(x).map(_.trim).filter(_.length > 0)
 
     val elements: List[Element] =
       doc.select("meta[name=description]").asScala.toList ++

--- a/src/test/scala/sectery/producers/HtmlSpec.scala
+++ b/src/test/scala/sectery/producers/HtmlSpec.scala
@@ -64,7 +64,7 @@ object HtmlSpec extends DefaultRunnableSpec:
           equalTo(
             Tx(
               "#foo",
-              "Some notes on the Scala language, libraries, and ecosystem."
+              "Notes on Scala"
             )
           )
         )

--- a/src/test/scala/sectery/producers/HtmlSpec.scala
+++ b/src/test/scala/sectery/producers/HtmlSpec.scala
@@ -60,13 +60,6 @@ object HtmlSpec extends DefaultRunnableSpec:
           )
           _ <- TestClock.adjust(1.seconds)
           m <- sent.take
-        yield assert(m)(
-          equalTo(
-            Tx(
-              "#foo",
-              "Notes on Scala"
-            )
-          )
-        )
+        yield assert(m)(equalTo(Tx("#foo", "Notes on Scala")))
       } @@ timeout(2.seconds)
     )


### PR DESCRIPTION
The description isn't always the most relevant descriptor.  This
switches to grabbing the title instead.  A follow-up to this could be
site-specific switching between title and description.