### PR TITLE
Parse humidity as a value from zero to one

### DIFF
--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -125,7 +125,7 @@ object DarkSky:
                   temperature = temperature,
                   temperatureHigh = temperatureHigh,
                   temperatureLow = temperatureLow,
-                  humidity = humidity,
+                  humidity = humidity * 100,
                   wind = windSpeed,
                   gusts = windGust,
                   uvIndex = uvIndex.toInt

--- a/src/test/scala/sectery/producers/WeatherSpec.scala
+++ b/src/test/scala/sectery/producers/WeatherSpec.scala
@@ -87,7 +87,7 @@ object WeatherSpec extends DefaultRunnableSpec:
             List(
               Tx(
                 "#foo",
-                "San Francisco: 60° (low 53°, high 63°), humidity 1%, wind 6 mph, UV 0, O3 15 (Good), PM2.5 0 (Good)"
+                "San Francisco: 60° (low 53°, high 63°), humidity 96%, wind 6 mph, UV 0, O3 15 (Good), PM2.5 0 (Good)"
               )
             )
           )


### PR DESCRIPTION
The Dark Sky API appears to give humidity as a value between zero and
one, but we have been treating it as a value between zero and 100.

This updates the parser to treat the value as a percentage rather than a
fraction.