### PR TITLE
Update HTML parser to find title and description

### DIFF
--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -36,7 +36,9 @@ object Html extends Producer:
           .map {
             case Response(200, _, body) =>
               val doc: Document = Jsoup.parse(body)
-              getTitle(doc).map(d => Tx(c, d))
+              (getTitle(doc).toSeq ++ getDescription(doc).toSeq).map(
+                d => Tx(c, d)
+              )
             case r =>
               LoggerFactory
                 .getLogger(this.getClass())
@@ -49,7 +51,7 @@ object Html extends Producer:
               .error("caught exception", e)
             ZIO.effectTotal(None)
           }
-          .map(_.toIterable)
+          .map(_.iterator.to(Iterable))
       case _ =>
         ZIO.effectTotal(None)
 

--- a/src/test/scala/sectery/producers/HtmlSpec.scala
+++ b/src/test/scala/sectery/producers/HtmlSpec.scala
@@ -59,7 +59,17 @@ object HtmlSpec extends DefaultRunnableSpec:
             )
           )
           _ <- TestClock.adjust(1.seconds)
-          m <- sent.take
-        yield assert(m)(equalTo(Tx("#foo", "Notes on Scala")))
+          ms <- sent.takeAll
+        yield assert(ms)(
+          equalTo(
+            List(
+              Tx("#foo", "Notes on Scala"),
+              Tx(
+                "#foo",
+                "Some notes on the Scala language, libraries, and ecosystem."
+              )
+            )
+          )
+        )
       } @@ timeout(2.seconds)
     )


### PR DESCRIPTION
First we looked for the description, then we switched to the title.  It
seems neither is reliably sufficient.  This updates the HTML parser to
look for both.