### PR TITLE
Don't allow PircBotX to block the main thread

### DIFF
--- a/src/main/scala/sectery/Bot.scala
+++ b/src/main/scala/sectery/Bot.scala
@@ -72,5 +72,5 @@ object Bot extends Sender:
   private def unsafeSend(m: Tx): Unit =
     bot.sendIRC.message(m.channel, m.message)
 
-  def start(): Unit =
-    bot.startBot()
+  def start(): UIO[Unit] =
+    ZIO.succeedBlocking(bot.startBot())

--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -54,11 +54,8 @@ object MessageQueues:
       _ <- Producer.init()
       inbox <- ZQueue.unbounded[Rx]
       outbox <- ZQueue.unbounded[Tx]
-      fiber0 <- ZIO
-        .succeed(println("wat"))
-        .fork // throwaway effect -- since 2.0.0-M1, the first .fork in this for comprehension never runs for some unknown reason
       fiber1 <- produce(inbox, outbox).forever.fork
       fiber2 <- send(outbox, sender)
         .repeat(Schedule.spaced(250.milliseconds))
         .fork
-    yield (inbox, List(fiber0, fiber1, fiber2))
+    yield (inbox, List(fiber1, fiber2))

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -21,7 +21,7 @@ object Sectery extends App:
       for
         (inbox, fibers) <- MessageQueues.loop(Bot)
         _ = Bot.receive = (m: Rx) => unsafeRunAsync(inbox.offer(m))
-        _ = Bot.start()
+        _ <- Bot.start()
         _ <- Fiber.joinAll(fibers)
       yield ExitCode.failure // should never exit
     go


### PR DESCRIPTION
This prevents `PircBotX.startBot()`, which blocks the calling thread,
from blocking subsequent effects by wrapping it in `IO#succeedBlocked`.
