### PR TITLE
Add support for @tell

### DIFF
--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -80,7 +80,8 @@ object Producer:
           airNowApiKey = sys.env("AIRNOW_API_KEY")
         ),
         Btc,
-        Version
+        Version,
+        Tell
       )
     )
 

--- a/src/main/scala/sectery/producers/Tell.scala
+++ b/src/main/scala/sectery/producers/Tell.scala
@@ -1,0 +1,113 @@
+package sectery.producers
+
+import java.sql.Date
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+import sectery.Db
+import sectery.Info
+import sectery.Producer
+import sectery.Rx
+import sectery.Tx
+import zio.Clock
+import zio.Has
+import zio.RIO
+import zio.UIO
+import zio.URIO
+import zio.ZIO
+
+object Tell extends Producer:
+
+  private val tell = """^@tell\s+(.+)\s+(.+)\s*$""".r
+
+  override def help(): Iterable[Info] =
+    Some(
+      Info(
+        "@tell",
+        "@tell <nick> <message>, e.g. @tell bob remember the milk"
+      )
+    )
+
+  override def init(): RIO[Db.Db, Unit] =
+    for
+      _ <- Db.query { conn =>
+        val s =
+          """|CREATE TABLE IF NOT EXISTS TELL (
+             |  `CHANNEL` VARCHAR(64) NOT NULL,
+             |  `FROM` VARCHAR(64) NOT NULL,
+             |  `TO` VARCHAR(64) NOT NULL,
+             |  `MESSAGE` VARCHAR(64) NOT NULL,
+             |  `TIMESTAMP` TIMESTAMP NOT NULL
+             |)
+             |""".stripMargin
+        val stmt = conn.createStatement
+        stmt.executeUpdate(s)
+        stmt.close
+      }
+    yield ()
+
+  override def apply(m: Rx): URIO[Db.Db with Has[Clock], Iterable[Tx]] =
+    m match
+      case Rx(c, from, tell(to, message)) =>
+        for {
+          now <- Clock.currentTime(TimeUnit.MILLISECONDS)
+          reply <- Db
+            .query { conn =>
+              val s =
+                "INSERT INTO TELL (`CHANNEL`, `FROM`, `TO`, `MESSAGE`, `TIMESTAMP`) VALUES (?, ?, ?, ?, ?)"
+              val stmt = conn.prepareStatement(s)
+              stmt.setString(1, c)
+              stmt.setString(2, from)
+              stmt.setString(3, to)
+              stmt.setString(4, message)
+              stmt.setDate(5, new Date(now))
+              stmt.executeUpdate()
+              stmt.close
+              Some(Tx(c, "I will let them know."))
+            }
+            .catchAll { e =>
+              LoggerFactory
+                .getLogger(this.getClass())
+                .error("caught exception", e)
+              ZIO.succeed(None)
+            }
+        } yield reply
+      case Rx(c, nick, _) =>
+        val increment =
+          for
+            messages <- Db.query { conn =>
+              val s =
+                "SELECT `FROM`, `MESSAGE`, `TIMESTAMP` FROM TELL WHERE `CHANNEL` = ? AND `TO` = ?"
+              val stmt = conn.prepareStatement(s)
+              stmt.setString(1, c)
+              stmt.setString(2, nick)
+              val rs = stmt.executeQuery()
+              var msgs: List[Tx] = Nil
+              while (rs.next()) {
+                val from = rs.getString("FROM")
+                val message = rs.getString("MESSAGE")
+                val timestamp = rs.getDate("TIMESTAMP")
+                msgs = Tx(
+                  c,
+                  s"${nick}: on ${timestamp}, ${from} said: ${message}"
+                ) :: msgs
+              }
+              stmt.close
+              msgs.reverse
+            }
+            _ <- Db.query { conn =>
+              val s =
+                "DELETE FROM TELL WHERE `CHANNEL` = ? AND `TO` = ?"
+              val stmt = conn.prepareStatement(s)
+              stmt.setString(1, c)
+              stmt.setString(2, nick)
+              stmt.executeUpdate()
+              stmt.close
+            }
+          yield messages
+        increment
+          .catchAll { e =>
+            LoggerFactory
+              .getLogger(this.getClass())
+              .error("caught exception", e)
+            ZIO.succeed(None)
+          }

--- a/src/test/scala/sectery/producers/HelpSpec.scala
+++ b/src/test/scala/sectery/producers/HelpSpec.scala
@@ -28,7 +28,7 @@ object HelpSpec extends DefaultRunnableSpec:
             List(
               Tx(
                 "#foo",
-                "@btc, @count, @eval, @ping, @stock, @time, @version, @wx, s///"
+                "@btc, @count, @eval, @ping, @stock, @tell, @time, @version, @wx, s///"
               ),
               Tx(
                 "#foo",

--- a/src/test/scala/sectery/producers/TellSpec.scala
+++ b/src/test/scala/sectery/producers/TellSpec.scala
@@ -1,0 +1,38 @@
+package sectery.producers
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import sectery._
+import zio.Inject._
+import zio._
+import zio.test.Assertion.equalTo
+import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
+
+object TellSpec extends DefaultRunnableSpec:
+  override def spec =
+    suite(getClass().getName())(
+      test("@tell leaves a message") {
+        for
+          _ <- TestClock.setDateTime(
+            OffsetDateTime.of(1970, 2, 11, 0, 0, 0, 0, ZoneOffset.UTC)
+          )
+          sent <- ZQueue.unbounded[Tx]
+          (inbox, _) <- MessageQueues
+            .loop(new MessageLogger(sent))
+            .inject_(TestDb(), TestHttp())
+          _ <- inbox.offer(Rx("#foo", "user1", "@tell user2 Howdy"))
+          _ <- inbox.offer(Rx("#foo", "user2", "Hey"))
+          _ <- TestClock.adjust(1.seconds)
+          ms <- sent.takeAll
+        yield assert(ms)(
+          equalTo(
+            List(
+              Tx("#foo", "I will let them know."),
+              Tx("#foo", "user2: on 1970-02-11, user1 said: Howdy")
+            )
+          )
+        )
+      } @@ timeout(2.seconds)
+    )


### PR DESCRIPTION
This allows a user to leave a message for another user, which they will
receive the next time they say something.

For example:

```
<user1> @tell user2 Howdy
<sectery> I will let them know.
<user2> Hey
<sectery> user2: on 1970-02-11, user1 said: Howdy
```

Fixes #210