### PR TITLE
Make the @tell regex nick group less greedy

### DIFF
--- a/src/main/scala/sectery/producers/Tell.scala
+++ b/src/main/scala/sectery/producers/Tell.scala
@@ -17,7 +17,7 @@ import zio.ZIO
 
 object Tell extends Producer:
 
-  private val tell = """^@tell\s+(.+)\s+(.+)\s*$""".r
+  private val tell = """^@tell\s+([^\s]+)\s+(.+)\s*$""".r
 
   override def help(): Iterable[Info] =
     Some(

--- a/src/test/scala/sectery/producers/TellSpec.scala
+++ b/src/test/scala/sectery/producers/TellSpec.scala
@@ -22,7 +22,7 @@ object TellSpec extends DefaultRunnableSpec:
           (inbox, _) <- MessageQueues
             .loop(new MessageLogger(sent))
             .inject_(TestDb(), TestHttp())
-          _ <- inbox.offer(Rx("#foo", "user1", "@tell user2 Howdy"))
+          _ <- inbox.offer(Rx("#foo", "user1", "@tell user2 Hi there!"))
           _ <- inbox.offer(Rx("#foo", "user2", "Hey"))
           _ <- TestClock.adjust(1.seconds)
           ms <- sent.takeAll
@@ -30,7 +30,7 @@ object TellSpec extends DefaultRunnableSpec:
           equalTo(
             List(
               Tx("#foo", "I will let them know."),
-              Tx("#foo", "user2: on 1970-02-11, user1 said: Howdy")
+              Tx("#foo", "user2: on 1970-02-11, user1 said: Hi there!")
             )
           )
         )


### PR DESCRIPTION
This prevents the nick group from matching on spaces, which would break
@tell for messages with more than one word.