### PR TITLE
Rollback zio to 2.0.0-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val scala3Version = "3.0.1"
-val zioVersion = "2.0.0-M3"
+val zioVersion = "2.0.0-M2"
 
 val enableScalafix =
   List(


### PR DESCRIPTION
Something changed between M2 and M3 that's causing blocking with the
current approach.  Rolling back to M2 until it can be addressed.