### PR TITLE
Move per-producer exception handling up a level

### DIFF
--- a/src/main/scala/sectery/Db.scala
+++ b/src/main/scala/sectery/Db.scala
@@ -37,7 +37,7 @@ object Db:
             .catchAll { e =>
               LoggerFactory
                 .getLogger(this.getClass())
-                .warn("caught exception; rolling back transaction", e)
+                .error("rolling back transaction")
               conn.rollback()
               ZIO.fail(e)
             }

--- a/src/main/scala/sectery/Finnhub.scala
+++ b/src/main/scala/sectery/Finnhub.scala
@@ -4,13 +4,12 @@ import org.json4s.JsonDSL._
 import org.json4s.MonadicJValue.jvalueToMonadic
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import org.slf4j.LoggerFactory
 import scala.util.Try
 import sectery.Http
 import zio.Has
+import zio.RIO
 import zio.Task
 import zio.ULayer
-import zio.URIO
 import zio.ZIO
 import zio.ZLayer
 
@@ -32,7 +31,7 @@ class Finnhub(apiToken: String):
       case JLong(x)    => Some(x.toFloat)
       case _           => None
 
-  def quote(symbol: String): URIO[Http.Http, Option[Quote]] =
+  def quote(symbol: String): RIO[Http.Http, Option[Quote]] =
     Http
       .request(
         method = "GET",
@@ -63,10 +62,4 @@ class Finnhub(apiToken: String):
           ZIO.attempt(quote)
         case _ =>
           ZIO.succeed(None)
-      }
-      .catchAll { e =>
-        LoggerFactory
-          .getLogger(this.getClass())
-          .error("caught exception", e)
-        ZIO.succeed(None)
       }

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -45,10 +45,10 @@ object Sectery extends App:
 
     val k0: URIO[Producer.Env, ExitCode] =
       k1
-        .catchAll { e =>
+        .catchAllCause { cause =>
           LoggerFactory
             .getLogger(this.getClass())
-            .error("caught exception", e)
+            .error(cause.prettyPrint)
           ZIO.succeed(ExitCode.failure)
         }
 

--- a/src/main/scala/sectery/producers/Btc.scala
+++ b/src/main/scala/sectery/producers/Btc.scala
@@ -17,12 +17,12 @@ import sectery.Rx
 import sectery.Tx
 import zio.Clock
 import zio.Has
-import zio.URIO
+import zio.RIO
 import zio.ZIO
 
 object Btc extends Producer:
 
-  private val findRate: URIO[Http.Http, Option[Double]] =
+  private val findRate: RIO[Http.Http, Option[Double]] =
     Http
       .request(
         method = "GET",
@@ -43,17 +43,11 @@ object Btc extends Producer:
               None
         }
       }
-      .catchAll { e =>
-        LoggerFactory
-          .getLogger(this.getClass())
-          .error("caught exception", e)
-        ZIO.succeed(None)
-      }
 
   override def help(): Iterable[Info] =
     Some(Info("@btc", "@btc"))
 
-  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, "@btc") =>
         findRate.flatMap {

--- a/src/main/scala/sectery/producers/Count.scala
+++ b/src/main/scala/sectery/producers/Count.scala
@@ -1,6 +1,5 @@
 package sectery.producers
 
-import org.slf4j.LoggerFactory
 import sectery.Db
 import sectery.Info
 import sectery.Producer
@@ -8,7 +7,6 @@ import sectery.Rx
 import sectery.Tx
 import zio.RIO
 import zio.UIO
-import zio.URIO
 import zio.ZIO
 
 object Count extends Producer:
@@ -26,47 +24,38 @@ object Count extends Producer:
       }
     yield ()
 
-  override def apply(m: Rx): URIO[Db.Db, Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db, Iterable[Tx]] =
     m match
       case Rx(channel, _, "@count") =>
-        val increment =
-          for
-            oldCount <- Db.query { conn =>
-              val q = "SELECT VALUE FROM COUNTER LIMIT 1"
-              val stmt = conn.createStatement
-              val rs = stmt.executeQuery(q)
-              val count =
-                if (rs.next()) {
-                  rs.getInt("VALUE")
-                } else {
-                  0
-                }
-              stmt.close
-              count
-            }
-            _ <- Db.query { conn =>
-              val s = "DELETE FROM COUNTER"
-              val stmt = conn.createStatement
-              stmt.executeUpdate(s)
-              stmt.close
-            }
-            newCount <- Db.query { conn =>
-              val count = oldCount + 1
-              val s = "INSERT INTO COUNTER (VALUE) VALUES (?)"
-              val stmt = conn.prepareStatement(s)
-              stmt.setInt(1, count)
-              stmt.executeUpdate
-              stmt.close
-              count
-            }
-          yield Some(Tx(channel, s"${newCount}"))
-        increment
-          .catchAll { e =>
-            LoggerFactory
-              .getLogger(this.getClass())
-              .error("caught exception", e)
-            ZIO.succeed(None)
+        for
+          oldCount <- Db.query { conn =>
+            val q = "SELECT VALUE FROM COUNTER LIMIT 1"
+            val stmt = conn.createStatement
+            val rs = stmt.executeQuery(q)
+            val count =
+              if (rs.next()) {
+                rs.getInt("VALUE")
+              } else {
+                0
+              }
+            stmt.close
+            count
           }
-          .map(_.toIterable)
+          _ <- Db.query { conn =>
+            val s = "DELETE FROM COUNTER"
+            val stmt = conn.createStatement
+            stmt.executeUpdate(s)
+            stmt.close
+          }
+          newCount <- Db.query { conn =>
+            val count = oldCount + 1
+            val s = "INSERT INTO COUNTER (VALUE) VALUES (?)"
+            val stmt = conn.prepareStatement(s)
+            stmt.setInt(1, count)
+            stmt.executeUpdate
+            stmt.close
+            count
+          }
+        yield Some(Tx(channel, s"${newCount}"))
       case _ =>
         ZIO.succeed(None)

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -10,7 +10,7 @@ import sectery.Rx
 import sectery.Tx
 import zio.Clock
 import zio.Has
-import zio.URIO
+import zio.RIO
 import zio.ZIO
 
 object Eval extends Producer:
@@ -20,7 +20,7 @@ object Eval extends Producer:
   override def help(): Iterable[Info] =
     Some(Info("@eval", "@eval <expression>, e.g. @eval 6 * 7"))
 
-  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, eval(expr)) =>
         val encExpr = URLEncoder.encode(expr, "UTF-8")
@@ -41,12 +41,5 @@ object Eval extends Producer:
                 .error(s"unexpected response: ${r}")
               None
           }
-          .catchAll { e =>
-            LoggerFactory
-              .getLogger(this.getClass())
-              .error("caught exception", e)
-            ZIO.succeed(None)
-          }
-          .map(_.toIterable)
       case _ =>
         ZIO.succeed(None)

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -13,7 +13,7 @@ import sectery.Rx
 import sectery.Tx
 import zio.Clock
 import zio.Has
-import zio.URIO
+import zio.RIO
 import zio.ZIO
 
 object Html extends Producer:
@@ -23,7 +23,7 @@ object Html extends Producer:
   override def help(): Iterable[Info] =
     None
 
-  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, url(url)) =>
         Http
@@ -45,13 +45,6 @@ object Html extends Producer:
                 .error(s"unexpected response: ${r}")
               None
           }
-          .catchAll { e =>
-            LoggerFactory
-              .getLogger(this.getClass())
-              .error("caught exception", e)
-            ZIO.succeed(None)
-          }
-          .map(_.iterator.to(Iterable))
       case _ =>
         ZIO.succeed(None)
 

--- a/src/main/scala/sectery/producers/LastMessage.scala
+++ b/src/main/scala/sectery/producers/LastMessage.scala
@@ -2,7 +2,6 @@ package sectery.producers
 
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
-import org.slf4j.LoggerFactory
 import scala.util.matching.Regex
 import sectery.Db
 import sectery.Info
@@ -13,7 +12,6 @@ import sectery.Tx
 import zio.Clock
 import zio.Has
 import zio.RIO
-import zio.URIO
 import zio.ZIO
 
 case class LastMessage(
@@ -47,41 +45,32 @@ object LastMessage extends Producer:
       }
     yield ()
 
-  override def apply(m: Rx): URIO[Db.Db with Has[Clock], Iterable[Tx]] =
-    val saveLastMessage =
-      for
-        _ <- Db.query { conn =>
-          val s =
-            "DELETE FROM LAST_MESSAGE WHERE CHANNEL = ? AND NICK = ?"
-          val stmt = conn.prepareStatement(s)
-          stmt.setString(1, m.channel)
-          stmt.setString(2, m.nick)
-          stmt.executeUpdate
-          stmt.close
-        }
-        nowMillis <- Clock.currentTime(TimeUnit.MILLISECONDS)
-        newCount <- Db.query { conn =>
-          val s =
-            "INSERT INTO LAST_MESSAGE (CHANNEL, NICK, MESSAGE, TIMESTAMP) VALUES (?, ?, ?, ?)"
-          val stmt = conn.prepareStatement(s)
-          stmt.setString(1, m.channel)
-          stmt.setString(2, m.nick)
-          stmt.setString(3, m.message)
-          stmt.setTimestamp(4, new Timestamp(nowMillis))
-          stmt.executeUpdate
-          stmt.close
-        }
-      yield None
-    saveLastMessage
-      .catchAll { e =>
-        LoggerFactory
-          .getLogger(this.getClass())
-          .error("caught exception", e)
-        ZIO.succeed(None)
+  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
+    for
+      _ <- Db.query { conn =>
+        val s =
+          "DELETE FROM LAST_MESSAGE WHERE CHANNEL = ? AND NICK = ?"
+        val stmt = conn.prepareStatement(s)
+        stmt.setString(1, m.channel)
+        stmt.setString(2, m.nick)
+        stmt.executeUpdate
+        stmt.close
       }
-      .map(_.toIterable)
+      nowMillis <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      newCount <- Db.query { conn =>
+        val s =
+          "INSERT INTO LAST_MESSAGE (CHANNEL, NICK, MESSAGE, TIMESTAMP) VALUES (?, ?, ?, ?)"
+        val stmt = conn.prepareStatement(s)
+        stmt.setString(1, m.channel)
+        stmt.setString(2, m.nick)
+        stmt.setString(3, m.message)
+        stmt.setTimestamp(4, new Timestamp(nowMillis))
+        stmt.executeUpdate
+        stmt.close
+      }
+    yield None
 
-  def lastMessages(channel: String): URIO[Db.Db, List[LastMessage]] =
+  def lastMessages(channel: String): RIO[Db.Db, List[LastMessage]] =
     Db.query { conn =>
       val s =
         """|SELECT NICK, MESSAGE, TIMESTAMP
@@ -106,17 +95,12 @@ object LastMessage extends Producer:
       }
       stmt.close
       ms.reverse
-    }.catchAll { e =>
-      LoggerFactory
-        .getLogger(this.getClass())
-        .error("caught exception", e)
-      ZIO.succeed(Nil)
-    }.map(_.toIterable)
+    }
 
   def lastMessage(
       channel: String,
       nick: String
-  ): URIO[Db.Db, Option[LastMessage]] =
+  ): RIO[Db.Db, Option[LastMessage]] =
     Db.query { conn =>
       val s =
         """|SELECT MESSAGE, TIMESTAMP
@@ -144,9 +128,4 @@ object LastMessage extends Producer:
       }
       stmt.close
       mo
-    }.catchAll { e =>
-      LoggerFactory
-        .getLogger(this.getClass())
-        .error("caught exception", e)
-      ZIO.succeed(None)
     }

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -1,6 +1,5 @@
 package sectery.producers
 
-import org.slf4j.LoggerFactory
 import sectery.Finnhub
 import sectery.Http
 import sectery.Info
@@ -10,9 +9,9 @@ import sectery.Rx
 import sectery.Tx
 import zio.Clock
 import zio.Has
+import zio.RIO
 import zio.Task
 import zio.UIO
-import zio.URIO
 import zio.ZIO
 
 class Stock(finnhubApiToken: String) extends Producer:
@@ -25,7 +24,7 @@ class Stock(finnhubApiToken: String) extends Producer:
   override def help(): Iterable[Info] =
     Some(Info("@stock", "@stock <symbol>, e.g. @stock GME"))
 
-  override def apply(m: Rx): URIO[Http.Http, Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, stock(symbol)) =>
         finnhub

--- a/src/main/scala/sectery/producers/Substitute.scala
+++ b/src/main/scala/sectery/producers/Substitute.scala
@@ -2,7 +2,6 @@ package sectery.producers
 
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
-import org.slf4j.LoggerFactory
 import scala.util.matching.Regex
 import sectery.Db
 import sectery.Info
@@ -13,7 +12,6 @@ import sectery.Tx
 import zio.Clock
 import zio.Has
 import zio.RIO
-import zio.URIO
 import zio.ZIO
 
 object Substitute extends Producer:
@@ -27,7 +25,7 @@ object Substitute extends Producer:
   override def help(): Iterable[Info] =
     Some(Info("s///", "s/find/replace/"))
 
-  override def apply(m: Rx): URIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
     m match
       case Rx(channel, nick, sub(toReplace, withReplace)) =>
         val matcher: Regex = new Regex(s".*${toReplace}.*")

--- a/src/main/scala/sectery/producers/Tell.scala
+++ b/src/main/scala/sectery/producers/Tell.scala
@@ -2,7 +2,6 @@ package sectery.producers
 
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
-import org.slf4j.LoggerFactory
 import sectery.Db
 import sectery.Info
 import sectery.Producer
@@ -12,7 +11,6 @@ import zio.Clock
 import zio.Has
 import zio.RIO
 import zio.UIO
-import zio.URIO
 import zio.ZIO
 
 object Tell extends Producer:
@@ -45,7 +43,7 @@ object Tell extends Producer:
       }
     yield ()
 
-  override def apply(m: Rx): URIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
     m match
       case Rx(c, from, tell(to, message)) =>
         for {
@@ -63,12 +61,6 @@ object Tell extends Producer:
               stmt.executeUpdate()
               stmt.close
               Some(Tx(c, "I will let them know."))
-            }
-            .catchAll { e =>
-              LoggerFactory
-                .getLogger(this.getClass())
-                .error("caught exception", e)
-              ZIO.succeed(None)
             }
         } yield reply
       case Rx(c, nick, _) =>
@@ -109,9 +101,3 @@ object Tell extends Producer:
             }
           yield messages
         increment
-          .catchAll { e =>
-            LoggerFactory
-              .getLogger(this.getClass())
-              .error("caught exception", e)
-            ZIO.succeed(None)
-          }


### PR DESCRIPTION
This moves most of the `catchAll` blocks out of the individual
producers, and adds a handler at the iterator that includes execution
tracing.