### PR TITLE
Allow users to set their local time zone

### DIFF
--- a/src/main/scala/sectery/producers/Config.scala
+++ b/src/main/scala/sectery/producers/Config.scala
@@ -50,7 +50,7 @@ object Config extends Producer:
       }
     yield ()
 
-  private def getConfig(
+  def getConfig(
       nick: String,
       key: String
   ): RIO[Db.Db, Option[String]] =

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -1,9 +1,9 @@
 package sectery.producers
 
 import java.text.SimpleDateFormat
-import java.util.concurrent.TimeUnit
 import java.util.Date
 import java.util.TimeZone
+import java.util.concurrent.TimeUnit
 import sectery.Db
 import sectery.Info
 import sectery.Producer

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -1,15 +1,17 @@
 package sectery.producers
 
 import java.text.SimpleDateFormat
+import java.util.concurrent.TimeUnit
 import java.util.Date
 import java.util.TimeZone
-import java.util.concurrent.TimeUnit
+import sectery.Db
 import sectery.Info
 import sectery.Producer
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
 import zio.Has
+import zio.RIO
 import zio.URIO
 import zio.ZIO
 
@@ -25,6 +27,9 @@ object Time extends Producer:
       )
     )
 
+  private def getTz(nick: String): RIO[Db.Db, Option[String]] =
+    Config.getConfig(nick, "tz")
+
   private def getTime(zone: String): URIO[Has[Clock], String] =
     for
       millis <- Clock.currentTime(TimeUnit.MILLISECONDS)
@@ -34,10 +39,17 @@ object Time extends Producer:
       pretty = sdf.format(date)
     yield pretty
 
-  override def apply(m: Rx): URIO[Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
     m match
-      case Rx(c, _, "@time") =>
-        getTime("America/Phoenix").map(t => Some(Tx(c, t)))
+      case Rx(c, nick, "@time") =>
+        for
+          zo <- getTz(nick)
+          t <- zo match
+            case Some(z) =>
+              getTime(z).map(t => Some(Tx(c, t)))
+            case None =>
+              getTime("America/Phoenix").map(t => Some(Tx(c, t)))
+        yield t
       case Rx(c, _, time(_, zone)) =>
         getTime(zone).map(t => Some(Tx(c, t)))
       case _ =>

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -27,9 +27,6 @@ object Time extends Producer:
       )
     )
 
-  private def getTz(nick: String): RIO[Db.Db, Option[String]] =
-    Config.getConfig(nick, "tz")
-
   private def getTime(zone: String): URIO[Has[Clock], String] =
     for
       millis <- Clock.currentTime(TimeUnit.MILLISECONDS)
@@ -43,7 +40,7 @@ object Time extends Producer:
     m match
       case Rx(c, nick, "@time") =>
         for
-          zo <- getTz(nick)
+          zo <- Config.getConfig(nick, "tz")
           t <- zo match
             case Some(z) =>
               getTime(z).map(t => Some(Tx(c, t)))


### PR DESCRIPTION
This uses `sectery.producers.Config` to check whether the user has
previously set `tz` to format responses to `@time` in their local time
zone.

Fixes #173