### PR TITLE
Choose random nick before random message

### DIFF
--- a/src/test/scala/sectery/producers/GrabSpec.scala
+++ b/src/test/scala/sectery/producers/GrabSpec.scala
@@ -20,9 +20,11 @@ object GrabSpec extends DefaultRunnableSpec:
           _ <- inbox.offer(Rx("#foo", "baz", "Howdy"))
           _ <- inbox.offer(Rx("#foo", "baz", "Hey"))
           _ <- inbox.offer(Rx("#foo", "bar", "@quote baz"))
+          _ <- inbox.offer(Rx("#foo", "bar", "@quote"))
           _ <- inbox.offer(Rx("#foo", "bar", "@grab bar"))
           _ <- inbox.offer(Rx("#foo", "bar", "@grab baz"))
           _ <- inbox.offer(Rx("#foo", "bar", "@quote baz"))
+          _ <- inbox.offer(Rx("#foo", "bar", "@quote"))
           _ <- TestClock.adjust(1.seconds)
           ms <- outbox.takeAll
         yield assert(ms)(
@@ -30,8 +32,10 @@ object GrabSpec extends DefaultRunnableSpec:
             List(
               Tx("#foo", "baz hasn't said anything."),
               Tx("#foo", "baz hasn't said anything."),
+              Tx("#foo", "Nobody has said anything."),
               Tx("#foo", "You can't grab yourself."),
               Tx("#foo", "Grabbed baz."),
+              Tx("#foo", "<baz> Hey"),
               Tx("#foo", "<baz> Hey")
             )
           )


### PR DESCRIPTION
This makes it equally likely that any nick will be randomly quoted,
regardless of how many of their messages have been grabbed.

This also makes the `nick` argument to `@quote` optional, selecting one
at random when it is omitted.