### PR TITLE
Strip leading <nick> from messages if present

### DIFF
--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -92,8 +92,11 @@ object Producer:
   def init(): RIO[Env, Iterable[Unit]] =
     ZIO.foreach(producers)(_.init())
 
-  def apply(m: Rx): URIO[Env, Iterable[Tx]] =
+  def apply(raw: Rx): URIO[Env, Iterable[Tx]] =
     ZIO.foldLeft(producers)(List.empty) { (txs, p) =>
+      val m = raw.copy(message =
+        raw.message.replaceAll("""^<[^>]*>\s*""", "")
+      )
       p.apply(m)
         .catchAllCause { cause =>
           LoggerFactory

--- a/src/test/scala/sectery/producers/GrabSpec.scala
+++ b/src/test/scala/sectery/producers/GrabSpec.scala
@@ -24,7 +24,7 @@ object GrabSpec extends DefaultRunnableSpec:
           _ <- inbox.offer(Rx("#foo", "bar", "@grab bar"))
           _ <- inbox.offer(Rx("#foo", "bar", "@grab baz"))
           _ <- inbox.offer(Rx("#foo", "bar", "@quote baz"))
-          _ <- inbox.offer(Rx("#foo", "bar", "@quote"))
+          _ <- inbox.offer(Rx("#foo", "bar", "<raz>@quote"))
           _ <- TestClock.adjust(1.seconds)
           ms <- outbox.takeAll
         yield assert(ms)(


### PR DESCRIPTION
Some IRC bridges prefix messages with `<nick>`, which throws off most of
the regex matching in Sectery's producers.  This removes it before
handing the message off to the producers.