### PR TITLE
Close each database connection at transaction end

### DIFF
--- a/src/main/scala/sectery/Db.scala
+++ b/src/main/scala/sectery/Db.scala
@@ -31,6 +31,7 @@ object Db:
               conn.setAutoCommit(false)
               val result: A = k(conn)
               conn.commit()
+              conn.close()
               result
             }
             .catchAll { e =>
@@ -38,6 +39,7 @@ object Db:
                 .getLogger(this.getClass())
                 .error("rolling back transaction")
               conn.rollback()
+              conn.close()
               ZIO.fail(e)
             }
     }


### PR DESCRIPTION
Database connections are a closeable resource.  This closes each one
after the transaction ends in either a commit or a rollback.