### PR TITLE
Move the leading nick stripper to the Rx extractor

### DIFF
--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -14,7 +14,21 @@ import zio.durationInt
 
 /** A message received from IRC.
   */
-case class Rx(channel: String, nick: String, message: String)
+class Rx(
+    val channel: String,
+    val nick: String,
+    val message: String
+)
+
+object Rx:
+  def unapply(r: Rx): Option[(String, String, String)] =
+    Some(
+      (
+        r.channel,
+        r.nick,
+        r.message.replaceAll("""^<[^>]*>\s*""", "")
+      )
+    )
 
 /** A message to send to IRC.
   */

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -92,11 +92,8 @@ object Producer:
   def init(): RIO[Env, Iterable[Unit]] =
     ZIO.foreach(producers)(_.init())
 
-  def apply(raw: Rx): URIO[Env, Iterable[Tx]] =
+  def apply(m: Rx): URIO[Env, Iterable[Tx]] =
     ZIO.foldLeft(producers)(List.empty) { (txs, p) =>
-      val m = raw.copy(message =
-        raw.message.replaceAll("""^<[^>]*>\s*""", "")
-      )
       p.apply(m)
         .catchAllCause { cause =>
           LoggerFactory

--- a/src/test/scala/sectery/producers/GrabSpec.scala
+++ b/src/test/scala/sectery/producers/GrabSpec.scala
@@ -25,6 +25,8 @@ object GrabSpec extends DefaultRunnableSpec:
           _ <- inbox.offer(Rx("#foo", "bar", "@grab baz"))
           _ <- inbox.offer(Rx("#foo", "bar", "@quote baz"))
           _ <- inbox.offer(Rx("#foo", "bar", "<raz>@quote"))
+          _ <- inbox.offer(Rx("#foo", "baz", "@grab bar"))
+          _ <- inbox.offer(Rx("#foo", "baz", "@quote bar"))
           _ <- TestClock.adjust(1.seconds)
           ms <- outbox.takeAll
         yield assert(ms)(
@@ -36,7 +38,9 @@ object GrabSpec extends DefaultRunnableSpec:
               Tx("#foo", "You can't grab yourself."),
               Tx("#foo", "Grabbed baz."),
               Tx("#foo", "<baz> Hey"),
-              Tx("#foo", "<baz> Hey")
+              Tx("#foo", "<baz> Hey"),
+              Tx("#foo", "Grabbed bar."),
+              Tx("#foo", "<bar> <raz>@quote")
             )
           )
         )


### PR DESCRIPTION
This changes `Rx` from a case class into a regular class with a manually
maintained extractor.  The extractor strips out any leading `<nick>`,
which allows matching on the clean message without losing access to the
raw message, e.g. for saving in the LAST_MESSAGE table.

This improves upon 7d4fd4fa87db17004b38c25d0b611f238a92a440