### PR TITLE
Trim leading and trailing whitespace for matching

### DIFF
--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -26,7 +26,9 @@ object Rx:
       (
         r.channel,
         r.nick,
-        r.message.replaceAll("""^<[^>]*>\s*""", "")
+        r.message
+          .replaceAll("""^<[^>]*>""", "")
+          .trim
       )
     )
 


### PR DESCRIPTION
This removes the need for individual pattern matches to allow for
leading and trailing whitespace.