### PR TITLE
Allow users to set default stock symbols

### DIFF
--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -1,5 +1,6 @@
 package sectery.producers
 
+import sectery.Db
 import sectery.Finnhub
 import sectery.Http
 import sectery.Info
@@ -25,41 +26,68 @@ class Stock(finnhubApiToken: String) extends Producer:
     Some(
       Info(
         "@stock",
-        "@stock <symbol1> [symbol2] ... [symbolN], e.g. @stock GME"
+        "@stock [symbol1] [symbol2] ... [symbolN], e.g. @stock GME"
       )
     )
 
-  override def apply(m: Rx): RIO[Http.Http, Iterable[Tx]] =
+  private def getStock(
+      symbolsString: String
+  ): RIO[Http.Http, Iterable[String]] =
+
+    val symbols: Set[String] =
+      symbolsString
+        .split("""[\s,]+""")
+        .map(_.trim())
+        .map(_.toUpperCase())
+        .toSet
+
+    val getSymbols: Set[RIO[Http.Http, Option[String]]] =
+      symbols.map { symbol =>
+        finnhub
+          .quote(symbol.toUpperCase())
+          .map {
+            case Some(q) =>
+              val current = q.current
+              val change = q.current - q.previousClose
+              val changeP = change * 100 / q.previousClose
+              Some(
+                f"""${symbol}: ${current}%.2f ${change}%+.2f (${changeP}%+.2f%%)"""
+              )
+            case None =>
+              Some(s"${symbol}: stonk not found")
+          }
+      }
+
+    ZIO.collectAll(getSymbols).map(_.flatten)
+
+  override def apply(m: Rx): RIO[Db.Db with Http.Http, Iterable[Tx]] =
     m match
       case Rx(c, _, stock(symbolsString, _, _)) =>
-        val symbols: Set[String] =
-          symbolsString
-            .split("""[\s,]+""")
-            .map(_.trim())
-            .map(_.toUpperCase())
-            .toSet
+        getStock(symbolsString).map(
+          _.map(m => Tx(channel = c, message = m))
+        )
 
-        val getSymbols: Set[RIO[Http.Http, Option[Tx]]] =
-          symbols.map { symbol =>
-            finnhub
-              .quote(symbol.toUpperCase())
-              .map {
-                case Some(q) =>
-                  val current = q.current
-                  val change = q.current - q.previousClose
-                  val changeP = change * 100 / q.previousClose
+      case Rx(c, nick, "@stock") =>
+        for
+          so <- Config.getConfig(nick, "stock")
+          txs <- so match
+            case Some(symbolsString) =>
+              val txs: RIO[Db.Db with Http.Http, Iterable[Tx]] =
+                getStock(symbolsString).map(
+                  _.map(m => Tx(channel = c, message = m))
+                )
+              txs
+            case None =>
+              val txs: RIO[Db.Db with Http.Http, Iterable[Tx]] =
+                ZIO.succeed(
                   Some(
                     Tx(
                       c,
-                      f"""${symbol}: ${current}%.2f ${change}%+.2f (${changeP}%+.2f%%)"""
+                      "Set default symbols with `@set stock <symbol1> [symbol2] ... [symbolN]`"
                     )
                   )
-                case None =>
-                  Some(Tx(c, s"${symbol}: stonk not found"))
-              }
-          }
-
-        ZIO.collectAll(getSymbols).map(_.flatten)
-
+                )
+              txs
+        yield txs
       case _ =>
         ZIO.succeed(None)

--- a/src/test/scala/sectery/producers/StockSpec.scala
+++ b/src/test/scala/sectery/producers/StockSpec.scala
@@ -62,6 +62,9 @@ object StockSpec extends DefaultRunnableSpec:
           _ <- inbox.offer(Rx("#foo", "bar", "@stock voo"))
           _ <- inbox.offer(Rx("#foo", "bar", "@stock FOO"))
           _ <- inbox.offer(Rx("#foo", "bar", "@stock VOO BAR"))
+          _ <- inbox.offer(Rx("#foo", "bar", "@stock"))
+          _ <- inbox.offer(Rx("#foo", "bar", "@set stock VOO BAR"))
+          _ <- inbox.offer(Rx("#foo", "bar", "@stock"))
           _ <- TestClock.adjust(1.seconds)
           ms <- outbox.takeAll
         yield assert((ms))(
@@ -70,6 +73,13 @@ object StockSpec extends DefaultRunnableSpec:
               Tx("#foo", "VOO: 390.09 +0.68 (+0.17%)"),
               Tx("#foo", "VOO: 390.09 +0.68 (+0.17%)"),
               Tx("#foo", "FOO: stonk not found"),
+              Tx("#foo", "VOO: 390.09 +0.68 (+0.17%)"),
+              Tx("#foo", "BAR: 1.00 +0.00 (+0.00%)"),
+              Tx(
+                "#foo",
+                "Set default symbols with `@set stock <symbol1> [symbol2] ... [symbolN]`"
+              ),
+              Tx("#foo", "bar: stock set to VOO BAR"),
               Tx("#foo", "VOO: 390.09 +0.68 (+0.17%)"),
               Tx("#foo", "BAR: 1.00 +0.00 (+0.00%)")
             )


### PR DESCRIPTION
This makes arguments to `@stock` optional, if a user has set a default.