### PR TITLE
Retrieve all subtitles for a given caption

### DIFF
--- a/src/main/scala/sectery/producers/Frinkiac.scala
+++ b/src/main/scala/sectery/producers/Frinkiac.scala
@@ -132,17 +132,12 @@ object Frinkiac extends Producer:
           for
             s <- ZIOO(Search.search(q).map(_.headOption))
             c <- ZIOO(Caption.caption(s.Episode, s.Timestamp))
-          yield List(
-            Some(
-              Tx(
-                channel,
-                s"https://frinkiac.com/caption/${s.Episode}/${s.Timestamp}"
-              )
-            ),
-            c.Subtitles.headOption
-              .map(_.Content)
-              .map(content => Tx(channel, content))
-          ).flatten
+          yield Tx(
+            channel,
+            s"https://frinkiac.com/caption/${s.Episode}/${s.Timestamp}"
+          ) :: c.Subtitles
+            .map(_.Content)
+            .map(content => Tx(channel, content))
         ).map(_.toList.flatten)
       case _ =>
         ZIO.succeed(None)

--- a/src/test/scala/sectery/producers/FrinkiacSpec.scala
+++ b/src/test/scala/sectery/producers/FrinkiacSpec.scala
@@ -71,6 +71,14 @@ object FrinkiacSpec extends DefaultRunnableSpec:
               Tx(
                 "#foo",
                 "DID I SAY THAT OR JUST THINK IT?"
+              ),
+              Tx(
+                "#foo",
+                "I GOT TO THINK OF A LIE FAST."
+              ),
+              Tx(
+                "#foo",
+                "HOMER, ARE YOU GOING TO THE DUFF BREWERY?"
               )
             )
           )


### PR DESCRIPTION
This updates `@frinkiac` to retrieve all available subtitles for a
selected caption, since there can be a few.