### PR TITLE
Don't save substitutions as last messages

### DIFF
--- a/src/main/scala/sectery/producers/Substitute.scala
+++ b/src/main/scala/sectery/producers/Substitute.scala
@@ -16,8 +16,8 @@ import zio.ZIO
 
 object Substitute extends Producer:
 
-  private val subOne = """s\/(.*)\/(.*)\/$""".r
-  private val subAll = """s\/(.*)\/(.*)\/g""".r
+  val subFirst = """s\/(.*)\/(.*)\/$""".r
+  val subAll = """s\/(.*)\/(.*)\/g""".r
 
   override def help(): Iterable[Info] =
     Some(Info("s///", "s/find/replace/"))
@@ -38,7 +38,7 @@ object Substitute extends Producer:
 
   override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
     m match
-      case Rx(channel, nick, subOne(toReplace, withReplace)) =>
+      case Rx(channel, nick, subFirst(toReplace, withReplace)) =>
         substitute(
           channel,
           toReplace,

--- a/src/test/scala/sectery/producers/SubstituteSpec.scala
+++ b/src/test/scala/sectery/producers/SubstituteSpec.scala
@@ -47,7 +47,7 @@ object SubstituteSpec extends DefaultRunnableSpec:
           ) // timestamps in db need to differ by at least a millisecond
           _ <- inbox.offer(Rx("#substitute", "waldo", "s/bar/baz/"))
           _ <- inbox.offer(Rx("#substitute", "waldo", "s/1/one/"))
-          _ <- inbox.offer(Rx("#substitute", "waldo", "s/2/two/g"))
+          _ <- inbox.offer(Rx("#substitute", "waldo", "s/1/one/g"))
           _ <- TestClock.adjust(1.seconds)
           ms <- outbox.takeAll
         yield assert(ms)(
@@ -55,7 +55,7 @@ object SubstituteSpec extends DefaultRunnableSpec:
             List(
               Tx("#substitute", "<baz> I said baz third."),
               Tx("#substitute", "<qux> one23 123 123"),
-              Tx("#substitute", "<qux> 1two3 1two3 1two3")
+              Tx("#substitute", "<qux> one23 one23 one23")
             )
           )
         )


### PR DESCRIPTION
This modifies the last message logger to ignore messages that match
either of the substitution patterns `s/foo/bar/[g]`.

Fixes #70