### PR TITLE
Set message delay from a shared config val

### DIFF
--- a/src/main/scala/sectery/Bot.scala
+++ b/src/main/scala/sectery/Bot.scala
@@ -4,6 +4,7 @@ import javax.net.ssl.SSLSocketFactory
 import org.pircbotx.Configuration
 import org.pircbotx.PircBotX
 import org.pircbotx.cap.SASLCapHandler
+import org.pircbotx.delay.StaticDelay
 import org.pircbotx.hooks.ListenerAdapter
 import org.pircbotx.hooks.events.JoinEvent
 import org.pircbotx.hooks.events.MessageEvent
@@ -23,6 +24,7 @@ class Bot(rx: Rx => Unit, tx: Tx => Unit)
         .setNickservPassword(sys.env("IRC_PASS"))
         .addServer(sys.env("IRC_HOST"), sys.env("IRC_PORT").toInt)
         .setAutoReconnect(true)
+        .setMessageDelay(new StaticDelay(Sectery.messageDelayMs))
         .addAutoJoinChannels(
           sys
             .env("IRC_CHANNELS")

--- a/src/main/scala/sectery/Sectery.scala
+++ b/src/main/scala/sectery/Sectery.scala
@@ -14,6 +14,8 @@ import zio.durationInt
 
 object Sectery extends App:
 
+  val messageDelayMs = 250
+
   /** This is the main entry point for the application. Set your env
     * vars, then run this main method.
     *
@@ -39,7 +41,7 @@ object Sectery extends App:
               bot.sendIRC.message(m.channel, m.message)
             }
           yield ()
-        ).repeat(Schedule.spaced(250.milliseconds)).fork
+        ).repeat(Schedule.spaced(messageDelayMs.milliseconds)).fork
         _ <- Fiber.joinAll(List(loopFiber, outboxFiber, botFiber))
       yield ExitCode.failure // should never exit
 


### PR DESCRIPTION
This adds a single place to set the message delay, and configures both
the ZIO scheduler and the PircBotX infrastructure to use it.