### PR TITLE
Add support for @blink

### DIFF
--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -86,7 +86,8 @@ object Producer:
         LastMessage,
         Grab,
         Config,
-        Frinkiac
+        Frinkiac,
+        Blink
       )
     )
 

--- a/src/main/scala/sectery/producers/Blink.scala
+++ b/src/main/scala/sectery/producers/Blink.scala
@@ -1,0 +1,31 @@
+package sectery.producers
+
+import sectery.Db
+import sectery.Finnhub
+import sectery.Http
+import sectery.Info
+import sectery.Producer
+import sectery.Response
+import sectery.Rx
+import sectery.Tx
+import zio.Clock
+import zio.Has
+import zio.RIO
+import zio.Task
+import zio.UIO
+import zio.ZIO
+
+object Blink extends Producer:
+
+  private val blink = """^@blink\s+(.+)$""".r
+
+  override def help(): Iterable[Info] =
+    Some(Info("@blink", "@blink <text>"))
+
+  override def apply(m: Rx): RIO[Db.Db with Http.Http, Iterable[Tx]] =
+    m match
+      case Rx(c, _, blink(text)) =>
+        val b = '\u0006'
+        ZIO.succeed(Some(Tx(c, s"${b}${text}${b}")))
+      case _ =>
+        ZIO.succeed(None)

--- a/src/test/scala/sectery/producers/BlinkSpec.scala
+++ b/src/test/scala/sectery/producers/BlinkSpec.scala
@@ -1,0 +1,27 @@
+package sectery.producers
+
+import sectery._
+import zio.Inject._
+import zio._
+import zio.test.Assertion.equalTo
+import zio.test.TestAspect._
+import zio.test._
+import zio.test.environment.TestClock
+
+object BlinkSpec extends DefaultRunnableSpec:
+  override def spec =
+    suite(getClass().getName())(
+      test("@blink foo produces blinking foo") {
+        for
+          (inbox, outbox, _) <- MessageQueues.loop
+            .inject_(TestDb(), TestHttp())
+          _ <- inbox.offer(Rx("#foo", "bar", "@blink foo"))
+          _ <- TestClock.adjust(1.seconds)
+          ms <- outbox.takeAll
+        yield assert(ms)(
+          equalTo(
+            List(Tx("#foo", "\u0006foo\u0006"))
+          )
+        )
+      } @@ timeout(2.seconds)
+    )

--- a/src/test/scala/sectery/producers/HelpSpec.scala
+++ b/src/test/scala/sectery/producers/HelpSpec.scala
@@ -27,6 +27,7 @@ object HelpSpec extends DefaultRunnableSpec:
               Tx(
                 "#foo",
                 List(
+                  "@blink",
                   "@btc",
                   "@count",
                   "@eval",


### PR DESCRIPTION
This reintroduces support for blinking text via `@blink <text>`, which
just echos text wrapped in unicode character U+0006.