### PR TITLE
Give @ascii vertical buffers, then trim each

### DIFF
--- a/src/main/scala/sectery/producers/Ascii.scala
+++ b/src/main/scala/sectery/producers/Ascii.scala
@@ -23,7 +23,8 @@ import zio.ZIO
 object Ascii extends Producer:
 
   private val width = 80
-  private val height = 10
+  private val height = 24
+  private val base = 16
 
   private val blink = """^@ascii\s+blink\s+(.+)$""".r
   private val ascii = """^@ascii\s+(.+)$""".r
@@ -48,9 +49,14 @@ object Ascii extends Producer:
     val i = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
     val g = i.getGraphics().asInstanceOf[Graphics2D]
     g.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12))
-    g.drawString(text, 0, height)
-    ((0 until height) map { y =>
-      (0 until width).map { x =>
-        if i.getRGB(x, y) == -16777216 then " " else "#"
-      }.mkString
-    }).dropWhile(_.trim().length == 0)
+    g.drawString(text, 0, base)
+    (0 until height)
+      .map { y =>
+        (0 until width).map { x =>
+          if i.getRGB(x, y) == -16777216 then " " else "#"
+        }.mkString
+      }
+      .dropWhile(_.trim().length == 0)
+      .reverse
+      .dropWhile(_.trim().length == 0)
+      .reverse


### PR DESCRIPTION
This adds some extra space above and below the image used to generate
`@ascii` results, so that nothing gets cut off.  Any extra remaining
space is trimmed at the end.