### PR TITLE
Update zio from 2.0.0-M4 to 2.0.0-M6-2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val scala3Version = "3.1.0"
-val zioVersion = "2.0.0-M4"
+val zioVersion = "2.0.0-M6-2"
 
 val enableScalafix =
   List(

--- a/src/main/scala/sectery/Autoquote.scala
+++ b/src/main/scala/sectery/Autoquote.scala
@@ -9,7 +9,6 @@ import sectery.Db
 import sectery.Tx
 import sectery.producers.Grab
 import zio.Clock
-import zio.Has
 import zio.Queue
 import zio.RIO
 import zio.URIO
@@ -105,7 +104,7 @@ object Autoquote:
 
   private def unsafeAutoquote(
       outbox: Queue[Tx]
-  ): RIO[Has[Clock] with Db.Db, Unit] =
+  ): RIO[Clock with Db.Db, Unit] =
     for
       nowMillis <- Clock.currentTime(TimeUnit.MILLISECONDS)
       _ <-
@@ -118,7 +117,7 @@ object Autoquote:
         else ZIO.succeed(())
     yield ()
 
-  def apply(outbox: Queue[Tx]): URIO[Has[Clock] with Db.Db, Unit] =
+  def apply(outbox: Queue[Tx]): URIO[Clock with Db.Db, Unit] =
     unsafeAutoquote(outbox)
       .catchAllCause { cause =>
         LoggerFactory

--- a/src/main/scala/sectery/Db.scala
+++ b/src/main/scala/sectery/Db.scala
@@ -7,12 +7,12 @@ import zio._
 
 object Db:
 
-  type Db = Has[Db.Service]
+  type Db = Db.Service
 
   trait Service:
     def apply[A](k: Connection => A): Task[A]
 
-  lazy val live: ULayer[Has[Service]] =
+  lazy val live: ULayer[Service] =
     ZLayer.succeed {
       new Service:
         // for info about the DATABASE_URL env var, see

--- a/src/main/scala/sectery/Finnhub.scala
+++ b/src/main/scala/sectery/Finnhub.scala
@@ -5,7 +5,6 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import scala.util.Try
 import sectery.Http
-import zio.Has
 import zio.RIO
 import zio.Task
 import zio.ULayer

--- a/src/main/scala/sectery/Http.scala
+++ b/src/main/scala/sectery/Http.scala
@@ -4,7 +4,6 @@ import java.net.HttpURLConnection
 import java.net.URL
 import scala.collection.JavaConverters._
 import scala.io.Source
-import zio.Has
 import zio.RIO
 import zio.Task
 import zio.ULayer
@@ -19,7 +18,7 @@ case class Response(
 
 object Http:
 
-  type Http = Has[Http.Service]
+  type Http = Http.Service
 
   trait Service:
     def request(
@@ -29,7 +28,7 @@ object Http:
         body: Option[String]
     ): Task[Response]
 
-  val live: ULayer[Has[Service]] =
+  val live: ULayer[Service] =
     ZLayer.succeed {
       new Service:
         def request(

--- a/src/main/scala/sectery/MessageQueues.scala
+++ b/src/main/scala/sectery/MessageQueues.scala
@@ -2,7 +2,6 @@ package sectery
 
 import sectery.Producer.Env
 import zio.Fiber
-import zio.Has
 import zio.Queue
 import zio.RIO
 import zio.Schedule

--- a/src/main/scala/sectery/Producer.scala
+++ b/src/main/scala/sectery/Producer.scala
@@ -3,7 +3,6 @@ package sectery
 import org.slf4j.LoggerFactory
 import sectery.producers._
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.UIO
 import zio.URIO
@@ -64,7 +63,7 @@ object Help {
 
 object Producer:
 
-  type Env = Db.Db with Http.Http with Has[Clock]
+  type Env = Db.Db with Http.Http with Clock
 
   private val producers: List[Producer] =
     Help(

--- a/src/main/scala/sectery/producers/Ascii.scala
+++ b/src/main/scala/sectery/producers/Ascii.scala
@@ -14,7 +14,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.Task
 import zio.UIO

--- a/src/main/scala/sectery/producers/Blink.scala
+++ b/src/main/scala/sectery/producers/Blink.scala
@@ -9,7 +9,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.Task
 import zio.UIO

--- a/src/main/scala/sectery/producers/Btc.scala
+++ b/src/main/scala/sectery/producers/Btc.scala
@@ -15,7 +15,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.ZIO
 

--- a/src/main/scala/sectery/producers/Config.scala
+++ b/src/main/scala/sectery/producers/Config.scala
@@ -11,7 +11,6 @@ import sectery.Producer
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.URIO
 import zio.ZIO

--- a/src/main/scala/sectery/producers/Eval.scala
+++ b/src/main/scala/sectery/producers/Eval.scala
@@ -9,7 +9,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.ZIO
 

--- a/src/main/scala/sectery/producers/Frinkiac.scala
+++ b/src/main/scala/sectery/producers/Frinkiac.scala
@@ -17,7 +17,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.ZIO
 

--- a/src/main/scala/sectery/producers/Grab.scala
+++ b/src/main/scala/sectery/producers/Grab.scala
@@ -9,7 +9,6 @@ import sectery.Producer
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.UIO
 import zio.ZIO
@@ -43,7 +42,7 @@ object Grab extends Producer:
       }
     yield ()
 
-  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Clock, Iterable[Tx]] =
     m match
       case Rx(c, from, grab(nick)) if from == nick =>
         ZIO.succeed(

--- a/src/main/scala/sectery/producers/Html.scala
+++ b/src/main/scala/sectery/producers/Html.scala
@@ -12,7 +12,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.ZIO
 

--- a/src/main/scala/sectery/producers/LastMessage.scala
+++ b/src/main/scala/sectery/producers/LastMessage.scala
@@ -11,7 +11,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.ZIO
 
@@ -62,7 +61,7 @@ object LastMessage extends Producer:
       createAutoquote(conn)
     }
 
-  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Clock, Iterable[Tx]] =
     m match
       case Rx(_, _, Substitute.subFirst(toReplace, withReplace)) =>
         ZIO.succeed(None)

--- a/src/main/scala/sectery/producers/Ping.scala
+++ b/src/main/scala/sectery/producers/Ping.scala
@@ -5,7 +5,6 @@ import sectery.Producer
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.URIO
 import zio.ZIO
 
@@ -14,7 +13,7 @@ object Ping extends Producer:
   override def help(): Iterable[Info] =
     Some(Info("@ping", "@ping"))
 
-  override def apply(m: Rx): URIO[Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): URIO[Clock, Iterable[Tx]] =
     m match
       case Rx(c, _, "@ping") =>
         ZIO.succeed(Some(Tx(c, "pong")))

--- a/src/main/scala/sectery/producers/Stock.scala
+++ b/src/main/scala/sectery/producers/Stock.scala
@@ -9,7 +9,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.Task
 import zio.UIO

--- a/src/main/scala/sectery/producers/Substitute.scala
+++ b/src/main/scala/sectery/producers/Substitute.scala
@@ -10,7 +10,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.ZIO
 
@@ -26,7 +25,7 @@ object Substitute extends Producer:
       channel: String,
       toReplace: String,
       howReplace: String => String
-  ): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  ): RIO[Db.Db with Clock, Iterable[Tx]] =
     val matcher: Regex = new Regex(s".*${toReplace}.*")
     Db { conn =>
       val ms = LastMessage.lastMessages(channel)(conn)
@@ -36,7 +35,7 @@ object Substitute extends Producer:
       }
     }
 
-  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Clock, Iterable[Tx]] =
     m match
       case Rx(channel, nick, subFirst(toReplace, withReplace)) =>
         substitute(

--- a/src/main/scala/sectery/producers/Tell.scala
+++ b/src/main/scala/sectery/producers/Tell.scala
@@ -9,7 +9,6 @@ import sectery.Producer
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.UIO
 import zio.ZIO
@@ -42,7 +41,7 @@ object Tell extends Producer:
       stmt.close
     }
 
-  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Clock, Iterable[Tx]] =
     m match
       case Rx(c, from, tell(to, message)) =>
         for {

--- a/src/main/scala/sectery/producers/Time.scala
+++ b/src/main/scala/sectery/producers/Time.scala
@@ -10,7 +10,6 @@ import sectery.Producer
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.URIO
 import zio.ZIO
@@ -27,7 +26,7 @@ object Time extends Producer:
       )
     )
 
-  private def getTime(zone: String): URIO[Has[Clock], String] =
+  private def getTime(zone: String): URIO[Clock, String] =
     for
       millis <- Clock.currentTime(TimeUnit.MILLISECONDS)
       date = new Date(millis)
@@ -36,7 +35,7 @@ object Time extends Producer:
       pretty = sdf.format(date)
     yield pretty
 
-  override def apply(m: Rx): RIO[Db.Db with Has[Clock], Iterable[Tx]] =
+  override def apply(m: Rx): RIO[Db.Db with Clock, Iterable[Tx]] =
     m match
       case Rx(c, nick, "@time") =>
         for

--- a/src/main/scala/sectery/producers/Weather.scala
+++ b/src/main/scala/sectery/producers/Weather.scala
@@ -16,7 +16,6 @@ import sectery.Response
 import sectery.Rx
 import sectery.Tx
 import zio.Clock
-import zio.Has
 import zio.RIO
 import zio.ZIO
 

--- a/src/test/scala/sectery/TestDb.scala
+++ b/src/test/scala/sectery/TestDb.scala
@@ -2,14 +2,13 @@ package sectery
 
 import java.sql.Connection
 import java.sql.DriverManager
-import zio.Has
 import zio.Task
 import zio.ULayer
 import zio.ZIO
 import zio.ZLayer
 
 object TestDb:
-  def apply(): ULayer[Has[Db.Service]] =
+  def apply(): ULayer[Db.Service] =
     ZLayer.succeed {
       new Db.Service:
         Class.forName("org.sqlite.JDBC");

--- a/src/test/scala/sectery/TestHttp.scala
+++ b/src/test/scala/sectery/TestHttp.scala
@@ -4,7 +4,7 @@ import zio._
 
 object TestHttp:
 
-  def apply(): ULayer[Has[Http.Service]] =
+  def apply(): ULayer[Http.Service] =
     apply(
       resStatus = 200,
       resHeaders = Map.empty,
@@ -15,8 +15,8 @@ object TestHttp:
       resStatus: Int,
       resHeaders: Map[String, String],
       resBody: String
-  ): ULayer[Has[Http.Service]] =
-    ZLayer.succeed {
+  ): ULayer[Http.Service] =
+    ZLayer.succeed[Http.Service] {
       new Http.Service:
         def request(
             method: String,

--- a/src/test/scala/sectery/producers/AsciiSpec.scala
+++ b/src/test/scala/sectery/producers/AsciiSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object AsciiSpec extends DefaultRunnableSpec:
 

--- a/src/test/scala/sectery/producers/BlinkSpec.scala
+++ b/src/test/scala/sectery/producers/BlinkSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object BlinkSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/BtcSpec.scala
+++ b/src/test/scala/sectery/producers/BtcSpec.scala
@@ -5,13 +5,13 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object BtcSpec extends DefaultRunnableSpec:
 
-  val http: ULayer[Has[Http.Service]] =
-    ZLayer.succeed {
+  val http: ULayer[Http.Service] =
+    ZLayer.succeed[Http.Service] {
       new Http.Service:
         def request(
             method: String,

--- a/src/test/scala/sectery/producers/ConfigSpec.scala
+++ b/src/test/scala/sectery/producers/ConfigSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object ConfigSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/CountSpec.scala
+++ b/src/test/scala/sectery/producers/CountSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object CountSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/EvalSpec.scala
+++ b/src/test/scala/sectery/producers/EvalSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object EvalSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/FrinkiacSpec.scala
+++ b/src/test/scala/sectery/producers/FrinkiacSpec.scala
@@ -5,13 +5,13 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object FrinkiacSpec extends DefaultRunnableSpec:
 
-  val http: ULayer[Has[Http.Service]] =
-    ZLayer.succeed {
+  val http: ULayer[Http.Service] =
+    ZLayer.succeed[Http.Service] {
       new Http.Service:
         def request(
             method: String,

--- a/src/test/scala/sectery/producers/GrabSpec.scala
+++ b/src/test/scala/sectery/producers/GrabSpec.scala
@@ -6,8 +6,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object GrabSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/HelpSpec.scala
+++ b/src/test/scala/sectery/producers/HelpSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object HelpSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/HtmlSpec.scala
+++ b/src/test/scala/sectery/producers/HtmlSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object HtmlSpec extends DefaultRunnableSpec:
   override def spec =
@@ -17,8 +17,8 @@ object HtmlSpec extends DefaultRunnableSpec:
           http = sys.env.get("TEST_HTTP_LIVE") match
             case Some("true") => Http.live
             case _ =>
-              val http: ULayer[Has[Http.Service]] =
-                ZLayer.succeed {
+              val http: ULayer[Http.Service] =
+                ZLayer.succeed[Http.Service] {
                   new Http.Service:
                     def request(
                         method: String,

--- a/src/test/scala/sectery/producers/PingSpec.scala
+++ b/src/test/scala/sectery/producers/PingSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object PingSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/StockSpec.scala
+++ b/src/test/scala/sectery/producers/StockSpec.scala
@@ -5,13 +5,13 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object StockSpec extends DefaultRunnableSpec:
 
-  private val http: ULayer[Has[Http.Service]] =
-    ZLayer.succeed {
+  private val http: ULayer[Http.Service] =
+    ZLayer.succeed[Http.Service] {
       new Http.Service:
         def request(
             method: String,

--- a/src/test/scala/sectery/producers/SubstituteSpec.scala
+++ b/src/test/scala/sectery/producers/SubstituteSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object SubstituteSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/TellSpec.scala
+++ b/src/test/scala/sectery/producers/TellSpec.scala
@@ -7,8 +7,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object TellSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/TimeSpec.scala
+++ b/src/test/scala/sectery/producers/TimeSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object TimeSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/VersionSpec.scala
+++ b/src/test/scala/sectery/producers/VersionSpec.scala
@@ -5,8 +5,8 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.matchesRegex
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object VersionSpec extends DefaultRunnableSpec:
   override def spec =

--- a/src/test/scala/sectery/producers/WeatherSpec.scala
+++ b/src/test/scala/sectery/producers/WeatherSpec.scala
@@ -5,13 +5,13 @@ import zio.Inject._
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect._
+import zio.test.TestClock
 import zio.test._
-import zio.test.environment.TestClock
 
 object WeatherSpec extends DefaultRunnableSpec:
 
-  val http: ULayer[Has[Http.Service]] =
-    ZLayer.succeed {
+  val http: ULayer[Http.Service] =
+    ZLayer.succeed[Http.Service] {
       new Http.Service:
         def request(
             method: String,

--- a/src/test/scala/zio/Inject.scala
+++ b/src/test/scala/zio/Inject.scala
@@ -3,32 +3,32 @@ package zio
 object Inject:
 
   implicit class Inject2[R0, R1, E, A](
-      z: ZIO[Has[R0] with Has[R1], E, A]
-  )(implicit t: Tag[Has[R1]]):
-    def inject_(r0: ULayer[Has[R0]]): ZIO[Has[R1], E, A] =
+      z: ZIO[R0 with R1, E, A]
+  )(implicit t: Tag[R1]):
+    def inject_(r0: ULayer[R0]): ZIO[R1, E, A] =
       ZIO.accessZIO { r =>
         z.provideLayer(r0 ++ ZLayer.succeedMany(r))
       }
 
   implicit class Inject3[R0, R1, R2, E, A](
-      z: ZIO[Has[R0] with Has[R1] with Has[R2], E, A]
-  )(implicit t1: Tag[Has[R1]], t2: Tag[Has[R2]]):
+      z: ZIO[R0 with R1 with R2, E, A]
+  )(implicit t1: Tag[R1], t2: Tag[R2]):
     def inject_(
-        r0: ULayer[Has[R0]],
-        r1: ULayer[Has[R1]]
-    ): ZIO[Has[R2], E, A] =
+        r0: ULayer[R0],
+        r1: ULayer[R1]
+    ): ZIO[R2, E, A] =
       ZIO.accessZIO { r =>
         z.provideLayer(r0 ++ r1 ++ ZLayer.succeedMany(r))
       }
 
   implicit class Inject4[R0, R1, R2, R3, E, A](
-      z: ZIO[Has[R0] with Has[R1] with Has[R2] with Has[R3], E, A]
-  )(implicit t1: Tag[Has[R1]], t2: Tag[Has[R2]], t3: Tag[Has[R3]]):
+      z: ZIO[R0 with R1 with R2 with R3, E, A]
+  )(implicit t1: Tag[R1], t2: Tag[R2], t3: Tag[R3]):
     def inject_(
-        r0: ULayer[Has[R0]],
-        r1: ULayer[Has[R1]],
-        r2: ULayer[Has[R2]]
-    ): ZIO[Has[R3], E, A] =
+        r0: ULayer[R0],
+        r1: ULayer[R1],
+        r2: ULayer[R2]
+    ): ZIO[R3, E, A] =
       ZIO.accessZIO { r =>
         z.provideLayer(r0 ++ r1 ++ r2 ++ ZLayer.succeedMany(r))
       }


### PR DESCRIPTION
* Drops `Has`, which has been [removed from ZIO][1]
* Adds an explicit type argument to `ZLayer.succeed`, without which this
  happens:

    ```
    [error]    |Exception occurred while executing macro expansion.
    [error]    |java.lang.RuntimeException: TYPEREPR, UNSUPPORTED: class dotty.tools.dotc.core.Types$CachedRefinedType - RefinedType(...)
    [error]    |    at izumi.reflect.dottyreflection.Inspector.inspectTypeRepr(Inspector.scala:96)
    [error]    |    at izumi.reflect.dottyreflection.Inspector.buildTypeRef(Inspector.scala:22)
    [error]    |    at izumi.reflect.dottyreflection.TypeInspections$.apply(TypeInspections.scala:10)
    [error]    |    at izumi.reflect.dottyreflection.Inspect$.inspectAny(Inspect.scala:18)
    [error]    |
    [error]    | This location contains code that was inlined from WeatherSpec.scala:71
    [error]    | This location contains code that was inlined from TagMacro.scala:22
    [error]    | This location contains code that was inlined from TagMacro.scala:22
    [error]    | This location contains code that was inlined from Tags.scala:145
    ```

[1]: https://github.com/zio/zio/releases/tag/v2.0.0-M6
