### PR TITLE
Add support for a pipe operator

### DIFF
--- a/src/main/scala/sectery/producers/Ascii.scala
+++ b/src/main/scala/sectery/producers/Ascii.scala
@@ -25,18 +25,13 @@ object Ascii extends Producer:
   private val height = 24
   private val base = 16
 
-  private val blink = """^@ascii\s+blink\s+(.+)$""".r
   private val ascii = """^@ascii\s+(.+)$""".r
 
   override def help(): Iterable[Info] =
-    Some(Info("@ascii", "@ascii [blink] <text>"))
+    Some(Info("@ascii", "@ascii <text>"))
 
   override def apply(m: Rx): RIO[Db.Db with Http.Http, Iterable[Tx]] =
     m match
-      case Rx(c, _, blink(text)) =>
-        ZIO.succeed(
-          ascii(text).map { line => Tx(c, s"\u0006${line}\u0006") }
-        )
       case Rx(c, _, ascii(text)) =>
         ZIO.succeed(
           ascii(text).map { line => Tx(c, line) }
@@ -51,9 +46,12 @@ object Ascii extends Producer:
     g.drawString(text, 0, base)
     (0 until height)
       .map { y =>
-        (0 until width).map { x =>
-          if i.getRGB(x, y) == -16777216 then " " else "#"
-        }.mkString
+        (0 until width)
+          .map { x =>
+            if i.getRGB(x, y) == -16777216 then " " else "#"
+          }
+          .mkString
+          .replaceAll("\\s*$", "")
       }
       .dropWhile(_.trim().length == 0)
       .reverse

--- a/src/main/scala/sectery/producers/Blink.scala
+++ b/src/main/scala/sectery/producers/Blink.scala
@@ -16,7 +16,7 @@ import zio.ZIO
 
 object Blink extends Producer:
 
-  private val blink = """^@blink\s+(.+)$""".r
+  private val blink = """^@blink\s(.+)$""".r
 
   override def help(): Iterable[Info] =
     Some(Info("@blink", "@blink <text>"))

--- a/src/test/scala/sectery/producers/AsciiSpec.scala
+++ b/src/test/scala/sectery/producers/AsciiSpec.scala
@@ -12,16 +12,16 @@ object AsciiSpec extends DefaultRunnableSpec:
 
   private val asciiFoo =
     List(
-      "    ##                                                                          ",
-      "   #                                                                            ",
-      "   #                                                                            ",
-      " #####   ###    ###                                                             ",
-      "   #    #   #  #   #                                                            ",
-      "   #    #   #  #   #                                                            ",
-      "   #    #   #  #   #                                                            ",
-      "   #    #   #  #   #                                                            ",
-      "   #    #   #  #   #                                                            ",
-      "   #     ###    ###                                                             "
+      "    ##",
+      "   #",
+      "   #",
+      " #####   ###    ###",
+      "   #    #   #  #   #",
+      "   #    #   #  #   #",
+      "   #    #   #  #   #",
+      "   #    #   #  #   #",
+      "   #    #   #  #   #",
+      "   #     ###    ###"
     )
 
   private val asciiFooTx =
@@ -42,7 +42,7 @@ object AsciiSpec extends DefaultRunnableSpec:
           (inbox, outbox, _) <- MessageQueues.loop
             .inject_(TestDb(), TestHttp())
           _ <- inbox.offer(Rx("#foo", "bar", "@ascii foo"))
-          _ <- inbox.offer(Rx("#foo", "bar", "@ascii blink foo"))
+          _ <- inbox.offer(Rx("#foo", "bar", "@ascii foo | @blink"))
           _ <- TestClock.adjust(1.seconds)
           ms <- outbox.takeAll
         yield assert(ms)(equalTo(asciiFooTx ++ asciiBlinkFooTx))

--- a/src/test/scala/sectery/producers/PipeSpec.scala
+++ b/src/test/scala/sectery/producers/PipeSpec.scala
@@ -1,0 +1,43 @@
+package sectery.producers
+
+import sectery._
+import zio.Inject._
+import zio._
+import zio.test.Assertion.equalTo
+import zio.test.TestAspect._
+import zio.test.TestClock
+import zio.test._
+
+object PipeSpec extends DefaultRunnableSpec:
+  override def spec =
+    suite(getClass().getName())(
+      test("pipe output into input") {
+        for
+          (inbox, outbox, _) <- MessageQueues.loop
+            .inject_(TestDb(), TestHttp())
+          _ <- inbox.offer(
+            Rx("#foo", "bar", "@morse encode foo | @blink")
+          )
+          _ <- inbox.offer(
+            Rx("#foo", "bar", "@morse encode foo | @morse decode")
+          )
+          _ <- inbox.offer(
+            Rx(
+              "#foo",
+              "bar",
+              "@morse encode foo | @morse decode | @morse encode"
+            )
+          )
+          _ <- TestClock.adjust(1.seconds)
+          ms <- outbox.takeAll
+        yield assert(ms)(
+          equalTo(
+            List(
+              Tx("#foo", "\u0006..-. --- ---\u0006"),
+              Tx("#foo", "FOO"),
+              Tx("#foo", "..-. --- ---")
+            )
+          )
+        )
+      } @@ timeout(2.seconds)
+    )


### PR DESCRIPTION
Also drop the `[blink]` argument from `@ascii` in favor of piping to
`@blink`.