### PR TITLE
Update from deprecated ZIO API

### DIFF
--- a/modules/producers/src/main/scala/sectery/Db.scala
+++ b/modules/producers/src/main/scala/sectery/Db.scala
@@ -47,4 +47,4 @@ object Db:
     }
 
   def apply[A](k: Connection => A): ZIO[Db, Throwable, A] =
-    ZIO.accessZIO(_.get.apply(k))
+    ZIO.environmentWithZIO(_.get.apply(k))

--- a/modules/producers/src/main/scala/sectery/Http.scala
+++ b/modules/producers/src/main/scala/sectery/Http.scala
@@ -51,7 +51,7 @@ object Http:
       headers: Map[String, String],
       body: Option[String]
   ): ZIO[Http, Throwable, Response] =
-    ZIO.accessZIO(_.get.request(method, url, headers, body))
+    ZIO.environmentWithZIO(_.get.request(method, url, headers, body))
 
   def unsafeRequest(
       method: String,


### PR DESCRIPTION
> method `accessZIO` in object `ZIO` is deprecated since 2.0.0: use
> `environmentWithZIO`