### PR TITLE
Format dates as "<duration> <time unit>s ago"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val producers =
     .in(file("modules/producers"))
     .enablePlugins(BuildInfoPlugin)
     .settings(
+      libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.2.Final",
       libraryDependencies += "org.postgresql" % "postgresql" % "42.3.1",
       libraryDependencies += "org.jsoup" % "jsoup" % "1.14.3",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.10",

--- a/modules/producers/src/main/scala/sectery/producers/Tell.scala
+++ b/modules/producers/src/main/scala/sectery/producers/Tell.scala
@@ -3,6 +3,7 @@ package sectery.producers
 import java.sql.Connection
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
+import org.ocpsoft.prettytime.PrettyTime
 import sectery.Db
 import sectery.Producer
 import sectery.Rx
@@ -76,9 +77,10 @@ object Tell extends Producer:
             val from = rs.getString("_FROM_")
             val message = rs.getString("_MESSAGE_")
             val timestamp = rs.getDate("_TIMESTAMP_")
+            val prettytime = (new PrettyTime).format(timestamp)
             msgs = Tx(
               c,
-              s"${nick}: on ${timestamp}, ${from} said: ${message}"
+              s"${nick}: ${prettytime}, ${from} said: ${message}"
             ) :: msgs
           }
           stmt.close

--- a/modules/producers/src/test/scala/sectery/producers/TellSpec.scala
+++ b/modules/producers/src/test/scala/sectery/producers/TellSpec.scala
@@ -29,8 +29,8 @@ object TellSpec extends ProducerSpec:
           List(
             Tx("#foo", "I will let them know."),
             Tx("#foo", "I will let them know."),
-            Tx("#foo", "user2: on 1970-02-11, user1 said: Howdy!"),
-            Tx("#foo", "user2: on 1970-02-12, user1 said: Hi there!")
+            Tx("#foo", "user2: 5 decades ago, user1 said: Howdy!"),
+            Tx("#foo", "user2: 5 decades ago, user1 said: Hi there!")
           )
         )
     )


### PR DESCRIPTION
This adds the [`PrettyTime` library][1] for formatting dates as relative
amounts of time in the past/future, and uses it for delivering `@tell`
messages.

[1]: https://github.com/ocpsoft/prettytime