### PR TITLE
Migrate from Heroku to AWS Elastic Beanstalk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.12.12
-        with:
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: "sectery"
-          heroku_email: "james@earldouglas.com"
+    - uses: actions/checkout@v1
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - run: sbt assembly
+    - uses: einaregilsson/beanstalk-deploy@v20
+      with:
+        aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        application_name: sectery
+        environment_name: sectery-env-worker
+        version_label: ${{ github.SHA }}
+        region: us-east-2
+        deployment_package: target/scala-3.1.0/sectery-assembly-0.1.0-SNAPSHOT.jar

--- a/build.sbt
+++ b/build.sbt
@@ -59,3 +59,5 @@ lazy val sectery =
     .dependsOn(irc)
     .dependsOn(producers)
     .aggregate(shared, irc, producers)
+
+Compile / packageBin / mainClass := Some("sectery.Main")

--- a/modules/producers/src/main/scala/sectery/Autoquote.scala
+++ b/modules/producers/src/main/scala/sectery/Autoquote.scala
@@ -4,6 +4,7 @@ import java.sql.Connection
 import java.sql.Timestamp
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
+import java.util.TimeZone
 import org.slf4j.LoggerFactory
 import sectery.Tx
 import sectery.Db
@@ -16,18 +17,18 @@ object Autoquote:
 
   private def timeForAutoquote(nowMillis: Long): Boolean =
 
+    val calendar: Calendar =
+      val tz = TimeZone.getTimeZone("America/Phoenix")
+      val c = Calendar.getInstance(tz)
+      c.setTimeInMillis(nowMillis)
+      c
+
     val eightToFive: Boolean =
-      val hourOfDay =
-        val c = Calendar.getInstance()
-        c.setTimeInMillis(nowMillis)
-        c.get(Calendar.HOUR_OF_DAY)
+      val hourOfDay = calendar.get(Calendar.HOUR_OF_DAY)
       hourOfDay >= 8 && hourOfDay < 17
 
     val mondayThroughFriday: Boolean =
-      val dayOfWeek =
-        val c = Calendar.getInstance()
-        c.setTimeInMillis(nowMillis)
-        c.get(Calendar.DAY_OF_WEEK)
+      val dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK)
       dayOfWeek == Calendar.MONDAY ||
       dayOfWeek == Calendar.TUESDAY ||
       dayOfWeek == Calendar.WEDNESDAY ||

--- a/modules/producers/src/test/scala/sectery/producers/GrabSpec.scala
+++ b/modules/producers/src/test/scala/sectery/producers/GrabSpec.scala
@@ -1,6 +1,7 @@
 package sectery.producers
 
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import sectery._
 import zio.Inject._
 import zio._
@@ -14,7 +15,7 @@ object GrabSpec extends ProducerSpec:
   override val pre =
     Some(
       TestClock.setDateTime {
-        val zo = OffsetDateTime.now().getOffset()
+        val zo = OffsetDateTime.now(ZoneId.of("UTC-7")).getOffset()
         OffsetDateTime.of(1970, 2, 11, 12, 0, 0, 0, zo)
       }
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")


### PR DESCRIPTION
1. Update the CD workflow to target AWS Elastic Beanstalk
2. Add sbt-assembly for packaging all dependencies in a single .jar file
3. Specify the main class to allow running via `java -jar assembly.jar`
4. Use UTC-7 for the autoquote time zone