### PR TITLE
Use Turnstyle to prevent concurrent runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Turnstyle
+      uses: softprops/turnstyle@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-java@v1
       with:
         java-version: 8

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Turnstyle
-      uses: softprops/turnstyle@v1
+    - uses: softprops/turnstyle@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-java@v1


### PR DESCRIPTION
Elastic Beanstalk doesn't like concurrent deployments, and will fail a
build when more than one are run at once:

> Environment named <env name> is in an invalid state for this
> operation. Must be Ready.

This adds [Turnstyle][1] to the deployment workflow to make deployments
wait until it's safe to go.

[1]: https://github.com/softprops/turnstyle