### PR TITLE
Use path filters to deploy modules individually

### DIFF
--- a/.github/workflows/deploy-irc.yml
+++ b/.github/workflows/deploy-irc.yml
@@ -1,0 +1,32 @@
+name: deploy irc
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '*'
+      - modules/shared/**
+      - modules/irc/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: softprops/turnstyle@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - run: sbt irc/assembly
+    - uses: einaregilsson/beanstalk-deploy@v20
+      with:
+        aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        application_name: sectery
+        environment_name: irc-env
+        version_label: irc-${{ github.SHA }}
+        region: us-east-2
+        deployment_package: modules/irc/target/scala-3.1.1/irc.jar

--- a/.github/workflows/deploy-producers.yml
+++ b/.github/workflows/deploy-producers.yml
@@ -1,9 +1,13 @@
-name: deploy
+name: deploy producers
 
 on:
   push:
     branches:
       - master
+    paths:
+      - '*'
+      - modules/shared/**
+      - modules/producers/**
 
 jobs:
   build:
@@ -16,7 +20,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: sbt assembly
+    - run: sbt producers/assembly
     - uses: einaregilsson/beanstalk-deploy@v20
       with:
         aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -26,12 +30,3 @@ jobs:
         version_label: producers-${{ github.SHA }}
         region: us-east-2
         deployment_package: modules/producers/target/scala-3.1.1/producers.jar
-    - uses: einaregilsson/beanstalk-deploy@v20
-      with:
-        aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        application_name: sectery
-        environment_name: irc-env
-        version_label: irc-${{ github.SHA }}
-        region: us-east-2
-        deployment_package: modules/irc/target/scala-3.1.1/irc.jar


### PR DESCRIPTION
We don't need to deploy the irc module when only the producers code has
changed (and vice versa).  This splits the deployment workflow into two,
one for each module.

For more info on filter patterns, see:
<https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths>