### PR TITLE
Revert "Update zio from 2.0.0-RC2 to 2.0.0-RC3 (#350)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "2.0.0-RC3"
+val zioVersion = "2.0.0-RC2"
 val zioAwsVersion = "5.17.151.1"
 
 ThisBuild / scalaVersion := "3.1.1"

--- a/modules/producers/src/main/scala/sectery/producers/Hack.scala
+++ b/modules/producers/src/main/scala/sectery/producers/Hack.scala
@@ -153,14 +153,11 @@ object Hack extends Producer:
   override def apply(m: Rx): ZIO[Db.Db, Throwable, Iterable[Tx]] =
     m match
       case Rx(c, _, "@hack") =>
-        for
-          game <- getOrStartGame(c)
-          (word, guessCount) = game
+        for (word, guessCount) <- getOrStartGame(c)
         yield Some(Tx(c, s"Guess a word with ${word.length} letters."))
       case Rx(c, _, hack(guess)) =>
         for
-          game <- getOrStartGame(c)
-          (word, guessCount) = game
+          (word, guessCount) <- getOrStartGame(c)
           found <- isAWord(guess)
           tx <-
             if guess.length != word.length then


### PR DESCRIPTION
This reverts commit 02e87f0ed8f1ee67a5af20a4d88b044b9dbcab5b.

zio-json is still compiled against RC2, which isn't compatible with RC3:

```
java.lang.NoClassDefFoundError: zio/ZManaged
```

Once zio-json migrates to RC3 we can reapply this update.