### PR TITLE
Roll ZIO back from 2.0.0-RC4 to 2.0.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "2.0.0-RC4"
+val zioVersion = "2.0.0-RC3"
 val zioAwsVersion = "5.17.162.1"
 
 ThisBuild / scalaVersion := "3.1.1"

--- a/modules/producers/src/test/scala/sectery/producers/ProducerSpec.scala
+++ b/modules/producers/src/test/scala/sectery/producers/ProducerSpec.scala
@@ -14,9 +14,9 @@ trait ProducerSpec extends ZIOSpecDefault:
   def testDb: ULayer[Db.Service] = TestDb()
   def http: ULayer[Http.Service] = TestHttp()
 
-  def pre: Option[ZIO[Clock, Nothing, Any]] = None
+  def pre: Option[ZIO[TestClock, Nothing, Any]] = None
 
-  type ZStep = ZIO[Db.Db, Throwable, Any]
+  type ZStep = ZIO[Db.Db & TestClock, Throwable, Any]
 
   def specs: Map[String, (List[Rx | ZStep], List[Tx])] =
     Map.empty


### PR DESCRIPTION
zio-aws and zio-json are still on RC3, so we can't update to RC4 yet.