### PR TITLE
zio-aws: 6.20.83.1 -> 6.20.83.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val zioVersion = "2.0.15"
-val zioAwsVersion = "6.20.83.1"
+val zioAwsVersion = "6.20.83.2"
 val zioJsonVersion = "0.6.0"
 val zioLoggingVersion = "2.1.13"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-55yslEKq1RJLnsPiWyQ/nnsjgggpZm89QOKLimv9E0s=";
+    depsSha256 = "sha256-3qfaxdAawfkcnFvttm3PzJ0J0A/ijS2KvTu7tsKEV9k=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates 
* [dev.zio:zio-aws-netty](https://github.com/zio/zio-aws)
* [dev.zio:zio-aws-sqs](https://github.com/zio/zio-aws)

 from `6.20.83.1` to `6.20.83.2`

📜 [GitHub Release Notes](https://github.com/zio/zio-aws/releases/tag/v6.20.83.2) - [Version Diff](https://github.com/zio/zio-aws/compare/v6.20.83.1...v6.20.83.2)