### PR TITLE
sbt: 1.9.1 -> 1.9.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-AuYrsk1b4TxdCID4TWXwwVm3tQrQkxFHJllCp2NUrCQ=";
+    depsSha256 = "sha256-uk5sTTP3pdT3B/BbGE46biq8EA5l2obq0CNg08e0OhI=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.1
+sbt.version=1.9.2


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.1` to `1.9.2`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.9.2) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.1...v1.9.2)