### PR TITLE
zio-aws: 6.20.83.2 -> 6.20.103.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val zioVersion = "2.0.15"
-val zioAwsVersion = "6.20.83.2"
+val zioAwsVersion = "6.20.103.1"
 val zioJsonVersion = "0.6.0"
 val zioLoggingVersion = "2.1.13"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-xtk3rjotMIDDZ+VUQxe+61Ss4prqxvfgIK0CxOQJhEo=";
+    depsSha256 = "sha256-FsR2hLAC+hg3dY9ZqZZg/7hUf80MiYb0XbbQfHswS5Y=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates 
* [dev.zio:zio-aws-netty](https://github.com/zio/zio-aws)
* [dev.zio:zio-aws-sqs](https://github.com/zio/zio-aws)

 from `6.20.83.2` to `6.20.103.1`

📜 [GitHub Release Notes](https://github.com/zio/zio-aws/releases/tag/v6.20.103.1) - [Version Diff](https://github.com/zio/zio-aws/compare/v6.20.83.2...v6.20.103.1)