### PR TITLE
scalafmt-core: 3.7.9 -> 3.7.10

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.7.9 // https://scalameta.org/scalafmt/docs/installation.html#sbt
+version = 3.7.10 // https://scalameta.org/scalafmt/docs/installation.html#sbt
 runner.dialect = scala3 // https://scalameta.org/scalafmt/docs/configuration.html#scala-3
 maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-LejGOYp625b849VURHg5OAAPBTp1uJd2gDjT2Yp5sV4=";
+    depsSha256 = "sha256-rPTr4baN49cY73UciOILcktZUI9qQWBBkYx2JO5lY4c=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scalameta:scalafmt-core](https://github.com/scalameta/scalafmt) from `3.7.9` to `3.7.10`

📜 [GitHub Release Notes](https://github.com/scalameta/scalafmt/releases/tag/v3.7.10) - [Version Diff](https://github.com/scalameta/scalafmt/compare/v3.7.9...v3.7.10)