### PR TITLE
sbt: 1.9.2 -> 1.9.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-NH3KUE1Gxly1zSsfnGl36J+wWBs9PZsXZFLHt2lKB1g=";
+    depsSha256 = "sha256-Oyxg0MOgjCTKh4Yulum5mJ/m36g2zoDaqd8uj6IkNKw=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.2
+sbt.version=1.9.3


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.2` to `1.9.3`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.9.3) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.2...v1.9.3)