### PR TITLE
amqp-client: 5.14.2 -> 5.14.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val shared =
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude ("dev.zio", "zio"),
       libraryDependencies += "dev.zio" %% "zio" % zioVersion,
       libraryDependencies += "dev.zio" %% "zio-json" % zioJsonVersion exclude ("dev.zio", "zio"),
-      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.14.2"
+      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.14.3"
     )
 
 lazy val irc =

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-82TtA2p+kX5OxH19QEa/cvYVV+JKgEkoovmWcNMians=";
+    depsSha256 = "sha256-m+S3nIo1W/qui28NZUvmrzs2OOu/RB4g5n0lx7/B8LQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client) from `5.14.2` to `5.14.3`

📜 [GitHub Release Notes](https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.14.3) - [Version Diff](https://github.com/rabbitmq/rabbitmq-java-client/compare/v5.14.2...v5.14.3)