### PR TITLE
zio-logging: 2.1.13 -> 2.1.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.0.15"
 val zioJsonVersion = "0.6.0"
-val zioLoggingVersion = "2.1.13"
+val zioLoggingVersion = "2.1.14"
 
 ThisBuild / scalaVersion := "3.3.0"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-m+S3nIo1W/qui28NZUvmrzs2OOu/RB4g5n0lx7/B8LQ=";
+    depsSha256 = "sha256-yRwkDul2qhZ7yjZyGmhJbdEo9LFvzrlJoA9c3iH2GJ4=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.1.13` to `2.1.14`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.1.14) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.1.13...v2.1.14)