### PR TITLE
amqp-client: 5.14.3 -> 5.18.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val shared =
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude ("dev.zio", "zio"),
       libraryDependencies += "dev.zio" %% "zio" % zioVersion,
       libraryDependencies += "dev.zio" %% "zio-json" % zioJsonVersion exclude ("dev.zio", "zio"),
-      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.14.3"
+      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.18.0"
     )
 
 lazy val irc =

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-yRwkDul2qhZ7yjZyGmhJbdEo9LFvzrlJoA9c3iH2GJ4=";
+    depsSha256 = "sha256-+uVsjsvGCkQjri1w+Wk7AcOYaNP8qmO+W2uCRsIM46c=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client) from `5.14.3` to `5.18.0`

📜 [GitHub Release Notes](https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.18.0) - [Version Diff](https://github.com/rabbitmq/rabbitmq-java-client/compare/v5.14.3...v5.18.0)