### PR TITLE
scalafmt-core: 3.7.12 -> 3.7.14

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.7.12 // https://scalameta.org/scalafmt/docs/installation.html#sbt
+version = 3.7.14 // https://scalameta.org/scalafmt/docs/installation.html#sbt
 runner.dialect = scala3 // https://scalameta.org/scalafmt/docs/configuration.html#scala-3
 maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-KTvImpkzre4ipPlY7HIMgl4MdEWy789IQC/LiZm3eOM=";
+    depsSha256 = "sha256-2BszYy9iyoGDQgkGUQgN7qTC6upU7XpuVKbXMJkBfTQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scalameta:scalafmt-core](https://github.com/scalameta/scalafmt) from `3.7.12` to `3.7.14`

📜 [GitHub Release Notes](https://github.com/scalameta/scalafmt/releases/tag/v3.7.14) - [Version Diff](https://github.com/scalameta/scalafmt/compare/v3.7.12...v3.7.14)