### PR TITLE
scala3-library: 3.3.0 -> 3.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val zioVersion = "2.0.16"
 val zioJsonVersion = "0.6.2"
 val zioLoggingVersion = "2.1.14"
 
-ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / scalaVersion := "3.3.1"
 
 ThisBuild / assembly / assemblyMergeStrategy := {
   case "module-info.class"                     => MergeStrategy.first

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-Ym9m0toOJbXJtGES024UVG7DhJYd3v3X12t7PWTAfkQ=";
+    depsSha256 = "sha256-R2nvPs55ErkgLvhT9s/ZOKZjvBvIDtWL65a6o7IyWtw=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala3-library](https://github.com/lampepfl/dotty) from `3.3.0` to `3.3.1`

📜 [GitHub Release Notes](https://github.com/lampepfl/dotty/releases/tag/3.3.1) - [Version Diff](https://github.com/lampepfl/dotty/compare/3.3.0...3.3.1) - [Version Diff](https://github.com/lampepfl/dotty/compare/release-3.3.0...release-3.3.1)