### PR TITLE
sbt: 1.9.4 -> 1.9.6

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-Ehr5eB9hixdxSJxVIBYFjrq1T0sIZd51QMl+ZijvTGI=";
+    depsSha256 = "sha256-WMsVopmH7udcT40SbdTp1/UJIEmqI8G+g0TLCd0QPjQ=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.4
+sbt.version=1.9.6


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.4` to `1.9.6`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.9.6) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.4...v1.9.6)