### PR TITLE
sbt-assembly: 2.1.1 -> 2.1.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-WMsVopmH7udcT40SbdTp1/UJIEmqI8G+g0TLCd0QPjQ=";
+    depsSha256 = "sha256-Xyx9apyhLbVhgcXAFOLy4mhqd/w3UcVLKXRih6rxKNE=";
 
     src = ./.;
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.3")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")


### PR DESCRIPTION
📦 Updates [com.eed3si9n:sbt-assembly](https://github.com/sbt/sbt-assembly) from `2.1.1` to `2.1.3`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-assembly/releases/tag/v2.1.3) - [Version Diff](https://github.com/sbt/sbt-assembly/compare/v2.1.1...v2.1.3)