### PR TITLE
jsoup: 1.16.1 -> 1.16.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val producers =
       libraryDependencies += "dev.zio" %% "zio-test" % zioVersion % "test",
       libraryDependencies += "dev.zio" %% "zio-test-sbt" % zioVersion % "test",
       libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.2.0",
-      libraryDependencies += "org.jsoup" % "jsoup" % "1.16.1",
+      libraryDependencies += "org.jsoup" % "jsoup" % "1.16.2",
       libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.7.Final",
       testFrameworks += new TestFramework(
         "zio.test.sbt.ZTestFramework"

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-QLPfKbcYDzTNk3qYN9ktPu/bUJPJu4aTSrE/l8op/7w=";
+    depsSha256 = "sha256-VQuwkTjB5w+7Cc/NVcDNMJHXzfs3JRun5c4NBcFIE2M=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.jsoup:jsoup](https://github.com/jhy/jsoup) from `1.16.1` to `1.16.2`