### PR TITLE
amqp-client: 5.19.0 -> 5.20.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val shared =
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude ("dev.zio", "zio"),
       libraryDependencies += "dev.zio" %% "zio" % zioVersion,
       libraryDependencies += "dev.zio" %% "zio-json" % zioJsonVersion exclude ("dev.zio", "zio"),
-      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.19.0"
+      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.20.0"
     )
 
 lazy val irc =

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-i50oH1oconTnkliaxiyt2aJkHocd++Uee4TlsnIhobg=";
+    depsSha256 = "sha256-Av5nzxK7XMxoHZ50w18ybExyUgAap4w+EPGw8lg2bZQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client) from `5.19.0` to `5.20.0`

📜 [GitHub Release Notes](https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.20.0) - [Version Diff](https://github.com/rabbitmq/rabbitmq-java-client/compare/v5.19.0...v5.20.0)