### PR TITLE
sbt: 1.9.6 -> 1.9.7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-Av5nzxK7XMxoHZ50w18ybExyUgAap4w+EPGw8lg2bZQ=";
+    depsSha256 = "sha256-Yb9pvPKK5zIm2LzEcguXXxo3qQKjprETJNXE78s6vr8=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.9.7


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.6` to `1.9.7`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.9.7) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.6...v1.9.7)