### PR TITLE
zio-logging: 2.1.14 -> 2.1.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.0.18"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.1.14"
+val zioLoggingVersion = "2.1.15"
 
 ThisBuild / scalaVersion := "3.3.1"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-mFXh4ufAi5h8Zuzb/aRy7YS0raMgSV2dYjqmaCtYfu8=";
+    depsSha256 = "sha256-gBABa1sZFJMNJKTFMCa0HEzC+bRLt+TILtEvQ6HBEk8=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.1.14` to `2.1.15`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.1.15) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.1.14...v2.1.15)