### PR TITLE
mariadb-java-client: 3.2.0 -> 3.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ ThisBuild / scalaVersion := "3.3.1"
 ThisBuild / assembly / assemblyMergeStrategy := {
   case "module-info.class"                     => MergeStrategy.first
   case "META-INF/io.netty.versions.properties" => MergeStrategy.first
+  case "META-INF/versions/9/module-info.class" => MergeStrategy.first
   case x =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
@@ -43,7 +44,7 @@ lazy val producers =
       libraryDependencies += "com.h2database" % "h2" % "2.2.224" % "test",
       libraryDependencies += "dev.zio" %% "zio-test" % zioVersion % "test",
       libraryDependencies += "dev.zio" %% "zio-test-sbt" % zioVersion % "test",
-      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.2.0",
+      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.3.0",
       libraryDependencies += "org.jsoup" % "jsoup" % "1.16.2",
       libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.7.Final",
       testFrameworks += new TestFramework(

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-U7iMbRdVehtAIFHGr9r77/aMoQkbnLN1JaeIVeFm6sk=";
+    depsSha256 = "sha256-W6pqc4Y/37HhoWmX+eMliw34+kuOnn6MHBLmaEVNaH8=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.mariadb.jdbc:mariadb-java-client](https://github.com/mariadb-corporation/mariadb-connector-j) from `3.2.0` to `3.3.0`

📜 [GitHub Release Notes](https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.3.0) - [Changelog](https://github.com/mariadb-corporation/mariadb-connector-j/blob/master/CHANGELOG.md) - [Version Diff](https://github.com/mariadb-corporation/mariadb-connector-j/compare/3.2.0...3.3.0)