### PR TITLE
zio-logging: 2.1.15 -> 2.1.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.0.19"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.1.15"
+val zioLoggingVersion = "2.1.16"
 
 ThisBuild / scalaVersion := "3.3.1"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-C2rDLVWWITRuCC/L6ozmAJBl1YGOIvb+RsyPq8ZTJOA=";
+    depsSha256 = "sha256-IQW2lSERJ6KHqikqjLeEzdF76DjuSzKiGJl7JWidmqg=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.1.15` to `2.1.16`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.1.16) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.1.15...v2.1.16)