### PR TITLE
jsoup: 1.16.2 -> 1.17.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val producers =
       libraryDependencies += "dev.zio" %% "zio-test" % zioVersion % "test",
       libraryDependencies += "dev.zio" %% "zio-test-sbt" % zioVersion % "test",
       libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.3.0",
-      libraryDependencies += "org.jsoup" % "jsoup" % "1.16.2",
+      libraryDependencies += "org.jsoup" % "jsoup" % "1.17.1",
       libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.7.Final",
       testFrameworks += new TestFramework(
         "zio.test.sbt.ZTestFramework"

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-IQW2lSERJ6KHqikqjLeEzdF76DjuSzKiGJl7JWidmqg=";
+    depsSha256 = "sha256-crLEEYxVS5yCaJywU5e8VHaXAPBFtHMA+X5yEDdZRM0=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.jsoup:jsoup](https://github.com/jhy/jsoup) from `1.16.2` to `1.17.1`

📜 [Changelog](https://github.com/jhy/jsoup/blob/master/CHANGES.md)