### PR TITLE
sbt: 1.9.7 -> 1.9.8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-ONumf30A+8TFBK3ZMrrXDsOK09TLl6yFlnC/vq7GlmE=";
+    depsSha256 = "sha256-kGdr6faJOcOAGDknMRlj76ruUsxlPj5ooo0OkrTYjpE=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.7` to `1.9.8`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.9.8) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.7...v1.9.8)