### PR TITLE
jsoup: 1.17.1 -> 1.17.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val producers =
       libraryDependencies += "dev.zio" %% "zio-test" % zioVersion % "test",
       libraryDependencies += "dev.zio" %% "zio-test-sbt" % zioVersion % "test",
       libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.3.1",
-      libraryDependencies += "org.jsoup" % "jsoup" % "1.17.1",
+      libraryDependencies += "org.jsoup" % "jsoup" % "1.17.2",
       libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.7.Final",
       testFrameworks += new TestFramework(
         "zio.test.sbt.ZTestFramework"

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-kGdr6faJOcOAGDknMRlj76ruUsxlPj5ooo0OkrTYjpE=";
+    depsSha256 = "sha256-BRhiK6mddsPtmKSMQFLefwoS4181Wq4oyurgOvO12C8=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.jsoup:jsoup](https://github.com/jhy/jsoup) from `1.17.1` to `1.17.2`

📜 [Changelog](https://github.com/jhy/jsoup/blob/master/CHANGES.md)