### PR TITLE
zio-logging: 2.1.16 -> 2.1.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.0.21"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.1.16"
+val zioLoggingVersion = "2.1.17"
 
 ThisBuild / scalaVersion := "3.3.1"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-dqiJt9D1dvEW9E2R4WP2e9Uos1qQQEfUcdX8QCnQbTU=";
+    depsSha256 = "sha256-exDuhRWErE6/grqNdwy1kpGKjeVbopdm4R7u2adxgtI=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.1.16` to `2.1.17`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.1.17) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.1.16...v2.1.17)