### PR TITLE
zio-logging: 2.1.17 -> 2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.0.21"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.1.17"
+val zioLoggingVersion = "2.2.0"
 
 ThisBuild / scalaVersion := "3.3.1"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-exDuhRWErE6/grqNdwy1kpGKjeVbopdm4R7u2adxgtI=";
+    depsSha256 = "sha256-ShF9g30qbjrZxusvAEZF63DCiBxql5SnyKUEIt/SEWE=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.1.17` to `2.2.0`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.2.0) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.1.17...v2.2.0)