### PR TITLE
zio-logging: 2.2.0 -> 2.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.0.21"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.2.0"
+val zioLoggingVersion = "2.2.1"
 
 ThisBuild / scalaVersion := "3.3.1"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-gg3nUjqeZ13nm/KqkIZ0hwLNVMR1muP36uxCuqTytZc=";
+    depsSha256 = "sha256-UXQWgllZzb3LvHs7ZD4gyfPNM1DoZBytuhSqMe1QErA=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.2.0` to `2.2.1`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.2.1) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.2.0...v2.2.1)