### PR TITLE
zio-logging: 2.2.1 -> 2.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.0.21"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.2.1"
+val zioLoggingVersion = "2.2.2"
 
 ThisBuild / scalaVersion := "3.3.1"
 

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-UXQWgllZzb3LvHs7ZD4gyfPNM1DoZBytuhSqMe1QErA=";
+    depsSha256 = "sha256-PqMaAeHls0ra61I+JGL2DKig6jmGEAcwOfJB/qitUaQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.2.1` to `2.2.2`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.2.2) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.2.1...v2.2.2)