### PR TITLE
sbt: 1.9.8 -> 1.9.9

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-jdbdG8rfzsRH1xQKITM43W7Fb39aHYS4u1pBP969OAM=";
+    depsSha256 = "sha256-rUwT7TbpS+Pxn9i4IVgRFc3lh354/cl1ee1/TeESFaM=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.8` to `1.9.9`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.9.9) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.8...v1.9.9)