### PR TITLE
scala3-library: 3.3.1 -> 3.3.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val zioVersion = "2.0.21"
 val zioJsonVersion = "0.6.2"
 val zioLoggingVersion = "2.2.2"
 
-ThisBuild / scalaVersion := "3.3.1"
+ThisBuild / scalaVersion := "3.3.3"
 
 ThisBuild / assembly / assemblyMergeStrategy := {
   case "module-info.class"                     => MergeStrategy.first

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-Qb7efHu/nMAktxsleB+aXegZ3fKiokYzoscJCh/5ets=";
+    depsSha256 = "sha256-T0gU9eSVFadNIhiAAoyJf/csIHkn6A7BFdxpjvZYyXk=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala3-library](https://github.com/lampepfl/dotty) from `3.3.1` to `3.3.3`

📜 [GitHub Release Notes](https://github.com/lampepfl/dotty/releases/tag/3.3.3) - [Version Diff](https://github.com/lampepfl/dotty/compare/3.3.1...3.3.3) - [Version Diff](https://github.com/lampepfl/dotty/compare/release-3.3.1...release-3.3.3)