### PR TITLE
sbt-assembly: 2.1.5 -> 2.2.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-T0gU9eSVFadNIhiAAoyJf/csIHkn6A7BFdxpjvZYyXk=";
+    depsSha256 = "sha256-aWzpZTlLpNJ8nSF6dCG3Go4wu/j4IysbIhQtJaxJmhM=";
 
     src = ./.;
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")


### PR DESCRIPTION
📦 Updates [com.eed3si9n:sbt-assembly](https://github.com/sbt/sbt-assembly) from `2.1.5` to `2.2.0`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-assembly/releases/tag/v2.2.0) - [Version Diff](https://github.com/sbt/sbt-assembly/compare/v2.1.5...v2.2.0)