### PR TITLE
scalafmt-core: 3.8.0 -> 3.8.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.8.0 // https://scalameta.org/scalafmt/docs/installation.html#sbt
+version = 3.8.1 // https://scalameta.org/scalafmt/docs/installation.html#sbt
 runner.dialect = scala3 // https://scalameta.org/scalafmt/docs/configuration.html#scala-3
 maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-tYCabN5jZPkCoz1FAg3lpYfRGn1Y8m+yDhGZ+5EK8mw=";
+    depsSha256 = "sha256-Ro9O/NbFwnj9UpyBnKBapEqunModvKW0JpX7Aa1Xrns=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scalameta:scalafmt-core](https://github.com/scalameta/scalafmt) from `3.8.0` to `3.8.1`

📜 [GitHub Release Notes](https://github.com/scalameta/scalafmt/releases/tag/v3.8.1) - [Version Diff](https://github.com/scalameta/scalafmt/compare/v3.8.0...v3.8.1)