### PR TITLE
sbt-native-packager: 1.9.16 -> 1.10.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-gDMbTT/+ejjLI2XqXThZ/DtGKnlI3tjR3KaDKmimFZI=";
+    depsSha256 = "sha256-Sfh0S78NSzjaJDglFvatIHfkZAPRVZjfm40HuNEZtNs=";
 
     src = ./.;
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.1")


### PR DESCRIPTION
📦 Updates [com.github.sbt:sbt-native-packager](https://github.com/sbt/sbt-native-packager) from `1.9.16` to `1.10.0`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-native-packager/releases/tag/v1.10.0) - [Changelog](https://github.com/sbt/sbt-native-packager/blob/master/CHANGELOG.md) - [Version Diff](https://github.com/sbt/sbt-native-packager/compare/v1.9.16...v1.10.0)