### PR TITLE
amqp-client: 5.20.0 -> 5.21.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val shared =
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude ("dev.zio", "zio"),
       libraryDependencies += "dev.zio" %% "zio" % zioVersion,
       libraryDependencies += "dev.zio" %% "zio-json" % zioJsonVersion exclude ("dev.zio", "zio"),
-      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.20.0"
+      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.21.0"
     )
 
 lazy val irc =

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-Sfh0S78NSzjaJDglFvatIHfkZAPRVZjfm40HuNEZtNs=";
+    depsSha256 = "sha256-gGS0FHX0Eds5ubtyPyM0gDHMdTqWAW8nH5sU981b9FQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client) from `5.20.0` to `5.21.0`

📜 [GitHub Release Notes](https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.21.0) - [Version Diff](https://github.com/rabbitmq/rabbitmq-java-client/compare/v5.20.0...v5.21.0)