### PR TITLE
zio-logging: 2.2.2 -> 2.2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.1.1"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.2.2"
+val zioLoggingVersion = "2.2.4"
 val testcontainersVersion = "0.41.3"
 
 ThisBuild / scalaVersion := "3.4.2"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-5sVi+66364Z0wBga5aamp3pDWJgn5y9YqWNn/Y1z3bA=";
+    depsSha256 = "sha256-DRlS+A289O5M8CzYAyeSwnvyaxvdwsdHX5ETz0OCn5o=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.2.2` to `2.2.4`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.2.4) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.2.2...v2.2.4)