### PR TITLE
mariadb-java-client: 3.3.3 -> 3.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,6 @@ lazy val adaptors =
   project
     .in(file("modules/4-adaptors"))
     .settings(
-      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.3.3",
       libraryDependencies += "dev.zio" %% "zio-json" % zioJsonVersion exclude ("dev.zio", "zio"),
       libraryDependencies += "com.h2database" % "h2" % "2.2.224" % Test,
       libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
@@ -86,7 +85,7 @@ lazy val producers =
     .in(file("modules/5-producers"))
     .settings(
       moduleName := "producers",
-      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.3.3",
+      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.4.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.3.14",
       assembly / mainClass := Some("sectery.producers.Main"),
       assembly / assemblyJarName := s"${name.value}.jar",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-DRlS+A289O5M8CzYAyeSwnvyaxvdwsdHX5ETz0OCn5o=";
+    depsSha256 = "sha256-rlLwGKvfgpot1e2azLIb1t0yt5G3EsFQwP5Go0UpxX4=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.mariadb.jdbc:mariadb-java-client](https://github.com/mariadb-corporation/mariadb-connector-j) from `3.3.3` to `3.4.0`

📜 [GitHub Release Notes](https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.4.0) - [Changelog](https://github.com/mariadb-corporation/mariadb-connector-j/blob/master/CHANGELOG.md) - [Version Diff](https://github.com/mariadb-corporation/mariadb-connector-j/compare/3.3.3...3.4.0)