### PR TITLE
prettytime: 5.0.7.Final -> 5.0.8.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val use_cases =
       buildInfoKeys := Seq[BuildInfoKey](version),
       buildInfoPackage := "sectery",
       libraryDependencies += "org.jsoup" % "jsoup" % "1.17.2",
-      libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.7.Final",
+      libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.8.Final",
       libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test,
       libraryDependencies += "org.scalameta" %% "munit-scalacheck" % "0.7.29" % Test
     )

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-rlLwGKvfgpot1e2azLIb1t0yt5G3EsFQwP5Go0UpxX4=";
+    depsSha256 = "sha256-NRYTZWr9C9qJri7ELZ54RT2K5MuOxZTJnLjaaXn2YIQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates org.ocpsoft.prettytime:prettytime from `5.0.7.Final` to `5.0.8.Final`