### PR TITLE
sbt: 1.9.9 -> 1.10.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-NRYTZWr9C9qJri7ELZ54RT2K5MuOxZTJnLjaaXn2YIQ=";
+    depsSha256 = "sha256-GjAqOlOdMArQEI43P49vfs3B4pRSPEjLc8ogh+9J1P0=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.9` to `1.10.0`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.10.0) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.9...v1.10.0)