### PR TITLE
zio-logging: 2.2.4 -> 2.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.1.1"
 val zioJsonVersion = "0.6.2"
-val zioLoggingVersion = "2.2.4"
+val zioLoggingVersion = "2.3.0"
 val testcontainersVersion = "0.41.3"
 
 ThisBuild / scalaVersion := "3.4.2"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-icO/Dlq8CIJMJdyTXwuafGEnD9jzw1izmUMAz4LcHVY=";
+    depsSha256 = "sha256-BSj3Dn85b54v3Ahg+wtvIV2cgHdOSqqxIvsqQ/96ygo=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.2.4` to `2.3.0`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.3.0) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.2.4...v2.3.0)