### PR TITLE
munit: 0.7.29 -> 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val domain =
   project
     .in(file("modules/1-domain"))
     .settings(
-      libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
+      libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test
     )
 
 lazy val effects =
@@ -28,7 +28,7 @@ lazy val effects =
     .in(file("modules/2-effects"))
     .dependsOn(domain)
     .settings(
-      libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
+      libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test
     )
 
 lazy val use_cases =
@@ -41,8 +41,8 @@ lazy val use_cases =
       libraryDependencies += "org.jsoup" % "jsoup" % "1.17.2",
       libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.8.Final",
       libraryDependencies += "net.objecthunter" % "exp4j" % "0.4.8",
-      libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test,
-      libraryDependencies += "org.scalameta" %% "munit-scalacheck" % "0.7.29" % Test
+      libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test,
+      libraryDependencies += "org.scalameta" %% "munit-scalacheck" % "1.0.0" % Test
     )
     .dependsOn(domain, effects)
 
@@ -52,7 +52,7 @@ lazy val adaptors =
     .settings(
       libraryDependencies += "dev.zio" %% "zio-json" % zioJsonVersion exclude ("dev.zio", "zio"),
       libraryDependencies += "com.h2database" % "h2" % "2.2.224" % Test,
-      libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
+      libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test
     )
     .dependsOn(effects)
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-BSj3Dn85b54v3Ahg+wtvIV2cgHdOSqqxIvsqQ/96ygo=";
+    depsSha256 = "sha256-I6OYwP5tkrUszEGk7T+NW6swseSEG+vOAz71cAgmm+s=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates 
* [org.scalameta:munit](https://github.com/scalameta/munit)
* [org.scalameta:munit-scalacheck](https://github.com/scalameta/munit-scalacheck)

 from `0.7.29` to `1.0.0` ⚠

📜 [GitHub Release Notes](https://github.com/scalameta/munit/releases/tag/v1.0.0) - [Version Diff](https://github.com/scalameta/munit/compare/v0.7.29...v1.0.0)