### PR TITLE
tyrus-standalone-client: 1.19 -> 1.21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,8 +102,8 @@ lazy val slack =
     .settings(
       moduleName := "slack",
       libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.39.3",
-      libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1",
-      libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "1.19",
+      libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
+      libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "1.21",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude ("dev.zio", "zio"),
       libraryDependencies += "dev.zio" %% "zio-logging-slf4j2" % zioLoggingVersion exclude ("dev.zio", "zio"),

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-XieN8+j2d0j/Z0O4+GZpx/3PPyrlBQXsmQi9C9fbBhs=";
+    depsSha256 = "sha256-eS0+UttDXtvZjd+g/GN3PGUqlFl8hLRhBDuWPJk82Fw=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.glassfish.tyrus.bundles:tyrus-standalone-client](https://github.com/eclipse-ee4j/tyrus) from `1.19` to `1.21`

📜 [GitHub Release Notes](https://github.com/eclipse-ee4j/tyrus/releases/tag/1.21) - [Version Diff](https://github.com/eclipse-ee4j/tyrus/compare/1.19...1.21)