### PR TITLE
testcontainers-scala-mariadb, ...: 0.41.3 -> 0.41.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val zioVersion = "2.1.2"
 val zioJsonVersion = "0.7.0"
 val zioLoggingVersion = "2.3.0"
-val testcontainersVersion = "0.41.3"
+val testcontainersVersion = "0.41.4"
 
 ThisBuild / scalaVersion := "3.4.2"
 ThisBuild / semanticdbEnabled := true

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-eS0+UttDXtvZjd+g/GN3PGUqlFl8hLRhBDuWPJk82Fw=";
+    depsSha256 = "sha256-z7b44Ywag6w4MF/Xeidniw+LU3KIHrdu8nkQ1yNpduo=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates 
* [com.dimafeng:testcontainers-scala-mariadb](https://github.com/testcontainers/testcontainers-scala)
* [com.dimafeng:testcontainers-scala-rabbitmq](https://github.com/testcontainers/testcontainers-scala)

 from `0.41.3` to `0.41.4`

📜 [GitHub Release Notes](https://github.com/testcontainers/testcontainers-scala/releases/tag/v0.41.4) - [Version Diff](https://github.com/testcontainers/testcontainers-scala/compare/v0.41.3...v0.41.4)