### PR TITLE
bolt-socket-mode: 1.39.3 -> 1.40.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.39.3",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.40.1",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "1.21",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-z7b44Ywag6w4MF/Xeidniw+LU3KIHrdu8nkQ1yNpduo=";
+    depsSha256 = "sha256-CREZW8QAzDkzEE+E7Mwzu+H27PE2OjqXIZ663bL8FiQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.slack.api:bolt-socket-mode](https://github.com/slackapi/java-slack-sdk) from `1.39.3` to `1.40.1`

📜 [GitHub Release Notes](https://github.com/slackapi/java-slack-sdk/releases/tag/v1.40.1) - [Version Diff](https://github.com/slackapi/java-slack-sdk/compare/v1.39.3...v1.40.1)