### PR TITLE
bolt-socket-mode: 1.40.1 -> 1.40.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.40.1",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.40.2",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.1.5",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-2+fFONDesZ8sPiqxU8GrPlqD9E5PTCJxV/GMIvcjuUQ=";
+    depsSha256 = "sha256-Ck7ztjWFu9pMrefiaFnl26vcCV/e1IFpuGIPSGQS+mI=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.slack.api:bolt-socket-mode](https://github.com/slackapi/java-slack-sdk) from `1.40.1` to `1.40.2`

📜 [GitHub Release Notes](https://github.com/slackapi/java-slack-sdk/releases/tag/v1.40.2) - [Version Diff](https://github.com/slackapi/java-slack-sdk/compare/v1.40.1...v1.40.2)