### PR TITLE
bolt-socket-mode: 1.40.2 -> 1.40.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.40.2",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.40.3",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.1.5",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-9rniIHBL56TQ9OzdYyVEpsYyEoqT5rspFdqZKcgHYbk=";
+    depsSha256 = "sha256-j7L6/HboMLBgnp+OjO0JO1PxVo2l6GMn7SCsSp0PwDM=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.slack.api:bolt-socket-mode](https://github.com/slackapi/java-slack-sdk) from `1.40.2` to `1.40.3`

📜 [GitHub Release Notes](https://github.com/slackapi/java-slack-sdk/releases/tag/v1.40.3) - [Version Diff](https://github.com/slackapi/java-slack-sdk/compare/v1.40.2...v1.40.3)