### PR TITLE
sbt: 1.10.0 -> 1.10.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ lazy val producers =
     .in(file("modules/5-producers"))
     .settings(
       moduleName := "producers",
-      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.4.0",
+      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.4.1",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val use_cases =
     .settings(
       buildInfoKeys := Seq[BuildInfoKey](version),
       buildInfoPackage := "sectery",
-      libraryDependencies += "org.jsoup" % "jsoup" % "1.17.2",
+      libraryDependencies += "org.jsoup" % "jsoup" % "1.18.1",
       libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.9.Final",
       libraryDependencies += "net.objecthunter" % "exp4j" % "0.4.8",
       libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "2.1.5"
+val zioVersion = "2.1.6"
 val zioJsonVersion = "0.7.1"
 val zioLoggingVersion = "2.3.0"
 val testcontainersVersion = "0.41.4"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-6WlCAXGQ9JMvN215wqno2T5Sz+vhjj7IwGhb7G46NSo=";
+    depsSha256 = "sha256-yXh0yMiY8KWjHeyb8tDUPZvFOraWO8VGKKE3pwqdtok=";
 
     src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-G6nyxil9khfaiCMt/2TVkRyEhB18RY355ak/OJOlWNE=";
+    depsSha256 = "sha256-6WlCAXGQ9JMvN215wqno2T5Sz+vhjj7IwGhb7G46NSo=";
 
     src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-j7L6/HboMLBgnp+OjO0JO1PxVo2l6GMn7SCsSp0PwDM=";
+    depsSha256 = "sha256-G6nyxil9khfaiCMt/2TVkRyEhB18RY355ak/OJOlWNE=";
 
     src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-yXh0yMiY8KWjHeyb8tDUPZvFOraWO8VGKKE3pwqdtok=";
+    depsSha256 = "sha256-NII58Ja2dguXvADtcLzjd+MBgprEACxP+mnQFMGWVpc=";
 
     src = ./.;
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.1


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.10.0` to `1.10.1`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.10.1) - [Version Diff](https://github.com/sbt/sbt/compare/v1.10.0...v1.10.1)