### PR TITLE
scalafmt-core: 3.8.2 -> 3.8.3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.8.2 // https://scalameta.org/scalafmt/docs/installation.html#sbt
+version = 3.8.3 // https://scalameta.org/scalafmt/docs/installation.html#sbt
 runner.dialect = scala3 // https://scalameta.org/scalafmt/docs/configuration.html#scala-3
 maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-NII58Ja2dguXvADtcLzjd+MBgprEACxP+mnQFMGWVpc=";
+    depsSha256 = "sha256-MFfp13MduiuexEmyV5Dxovhiik1F7aqzZczjBYwMm0o=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scalameta:scalafmt-core](https://github.com/scalameta/scalafmt) from `3.8.2` to `3.8.3`

📜 [GitHub Release Notes](https://github.com/scalameta/scalafmt/releases/tag/v3.8.3) - [Version Diff](https://github.com/scalameta/scalafmt/compare/v3.8.2...v3.8.3)