### PR TITLE
sbt-native-packager: 1.10.0 -> 1.10.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-MFfp13MduiuexEmyV5Dxovhiik1F7aqzZczjBYwMm0o=";
+    depsSha256 = "sha256-DBq19uUQXSaeUAM4aHzluJo58L3xM9WHQvxvfTrGi6c=";
 
     src = ./.;
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.1")


### PR DESCRIPTION
📦 Updates [com.github.sbt:sbt-native-packager](https://github.com/sbt/sbt-native-packager) from `1.10.0` to `1.10.4`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-native-packager/releases/tag/v1.10.4) - [Changelog](https://github.com/sbt/sbt-native-packager/blob/master/CHANGELOG.md) - [Version Diff](https://github.com/sbt/sbt-native-packager/compare/v1.10.0...v1.10.4)