### PR TITLE
tyrus-standalone-client: 2.1.5 -> 2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,7 @@ lazy val slack =
       moduleName := "slack",
       libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.40.3",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
-      libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.1.5",
+      libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-DBq19uUQXSaeUAM4aHzluJo58L3xM9WHQvxvfTrGi6c=";
+    depsSha256 = "sha256-5Vj1Q6nwAaHOqf08RZkncKT3RXvXOC03+ne9/CR2nUI=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.glassfish.tyrus.bundles:tyrus-standalone-client](https://github.com/eclipse-ee4j/tyrus) from `2.1.5` to `2.2.0`

📜 [GitHub Release Notes](https://github.com/eclipse-ee4j/tyrus/releases/tag/2.2.0) - [Version Diff](https://github.com/eclipse-ee4j/tyrus/compare/2.1.5...2.2.0)