### PR TITLE
bolt-socket-mode: 1.40.3 -> 1.42.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.40.3",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.42.0",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-mo5ZOc2j5eCYnNPhsTBUirOgRqlIuo4J32zCTNYlYGc=";
+    depsSha256 = "sha256-wn+MgS1hBcyA4R1ubaZIi3Vny7wZQk4tpmR16OfsYSY=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.slack.api:bolt-socket-mode](https://github.com/slackapi/java-slack-sdk) from `1.40.3` to `1.42.0`

📜 [GitHub Release Notes](https://github.com/slackapi/java-slack-sdk/releases/tag/v1.42.0) - [Version Diff](https://github.com/slackapi/java-slack-sdk/compare/v1.40.3...v1.42.0)