### PR TITLE
zio: 2.1.6 -> 2.1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "2.1.6"
+val zioVersion = "2.1.8"
 val zioJsonVersion = "0.7.1"
 val zioLoggingVersion = "2.3.0"
 val testcontainersVersion = "0.41.4"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-wn+MgS1hBcyA4R1ubaZIi3Vny7wZQk4tpmR16OfsYSY=";
+    depsSha256 = "sha256-0Xr+ynNZFmNPoOcJf/n9HgfaZ4zHO7UF/gvuSXuwPWc=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.1.6` to `2.1.8`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.8) - [Version Diff](https://github.com/zio/zio/compare/v2.1.6...v2.1.8)