### PR TITLE
zio-logging: 2.3.0 -> 2.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val zioVersion = "2.1.8"
 val zioJsonVersion = "0.7.2"
-val zioLoggingVersion = "2.3.0"
+val zioLoggingVersion = "2.3.1"
 val testcontainersVersion = "0.41.4"
 
 ThisBuild / scalaVersion := "3.4.2"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-4kboOH4CphUZYjHCcAqaUEsOMbin6Mqp2Aoa361APSk=";
+    depsSha256 = "sha256-VfHvJ8s757tD+krCic2PYx0YTW+1oQmon5gR5uBjn0g=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio-logging](https://github.com/zio/zio-logging) from `2.3.0` to `2.3.1`

📜 [GitHub Release Notes](https://github.com/zio/zio-logging/releases/tag/v2.3.1) - [Version Diff](https://github.com/zio/zio-logging/compare/v2.3.0...v2.3.1)