### PR TITLE
scala3-library: 3.4.2 -> 3.4.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val zioJsonVersion = "0.7.2"
 val zioLoggingVersion = "2.3.1"
 val testcontainersVersion = "0.41.4"
 
-ThisBuild / scalaVersion := "3.4.2"
+ThisBuild / scalaVersion := "3.4.3"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-VfHvJ8s757tD+krCic2PYx0YTW+1oQmon5gR5uBjn0g=";
+    depsSha256 = "sha256-B69iIPiBYSAS5OmTgmHDzh6UmGTK79DN18PI7KcpLVQ=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala3-library](https://github.com/scala/scala3) from `3.4.2` to `3.4.3`

📜 [GitHub Release Notes](https://github.com/scala/scala3/releases/tag/3.4.3) - [Version Diff](https://github.com/scala/scala3/compare/3.4.2...3.4.3) - [Version Diff](https://github.com/scala/scala3/compare/release-3.4.2...release-3.4.3)