### PR TITLE
logback-classic: 1.5.6 -> 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val producers =
     .settings(
       moduleName := "producers",
       libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.4.1",
-      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.7",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",
         "zio"
@@ -99,7 +99,7 @@ lazy val irc =
       moduleName := "irc",
       resolvers += "jitpack" at "https://jitpack.io/", // needed for pircbotx
       libraryDependencies += "com.github.pircbotx" % "pircbotx" % "2.3.1",
-      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.7",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",
         "zio"
@@ -122,7 +122,7 @@ lazy val slack =
       libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.42.0",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.0",
-      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.6",
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.7",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",
         "zio"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-9Mb4Dretc0tmLYmD7czr1oQZULNJI90WdE4UVVHVWrs=";
+    depsSha256 = "sha256-FRY4TmrId75+/7AqXLxUk60sUfgWj4Kt0ZQmQKK29AU=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [ch.qos.logback:logback-classic](https://github.com/qos-ch/logback) from `1.5.6` to `1.5.7`