### PR TITLE
scala3-library: 3.4.3 -> 3.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val zioJsonVersion = "0.7.3"
 val zioLoggingVersion = "2.3.1"
 val testcontainersVersion = "0.41.4"
 
-ThisBuild / scalaVersion := "3.4.3"
+ThisBuild / scalaVersion := "3.5.0"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-bviNlngl20EWztyoD4SBkuucAZyIehs9Qv2pyfiszuw=";
+    depsSha256 = "sha256-/h92DeQsSr9CHMpszo8V9Bwp/EpUjANkJD1UVxQX4Is=";
 
     src = ./.;
 

--- a/modules/5-slack/src/main/scala/slack/Slack.scala
+++ b/modules/5-slack/src/main/scala/slack/Slack.scala
@@ -12,8 +12,6 @@ import com.slack.api.model.event.MessageEvent
 import scala.jdk.CollectionConverters._
 import sectery._
 import sectery.adaptors._
-import sectery.domain.entities.Rx
-import sectery.domain.entities.Tx
 import sectery.domain.entities._
 import sectery.domain.operations._
 import sectery.effects._

--- a/src/test/scala/Main.scala
+++ b/src/test/scala/Main.scala
@@ -4,7 +4,6 @@ import com.dimafeng.testcontainers.MariaDBContainer
 import com.dimafeng.testcontainers.RabbitMQContainer
 import java.sql.Connection
 import java.sql.DriverManager
-import sectery.irc.Bot
 import zio.ExitCode
 import zio.Fiber
 import zio.Runtime


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala3-library](https://github.com/scala/scala3) from `3.4.3` to `3.5.0`

📜 [GitHub Release Notes](https://github.com/scala/scala3/releases/tag/3.5.0) - [Version Diff](https://github.com/scala/scala3/compare/3.4.3...3.5.0) - [Version Diff](https://github.com/scala/scala3/compare/release-3.4.3...release-3.5.0)