### PR TITLE
bolt-socket-mode: 1.42.0 -> 1.42.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.42.0",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.42.1",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.8",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-EDWmX5o8rNASFUbXyTG/T8B84obmccddmWPux33hpFI=";
+    depsSha256 = "sha256-PMp1Ty/Dp3stC6E7NKvFVcdqVEPHtPtKc5q/IqCiyd0=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [com.slack.api:bolt-socket-mode](https://github.com/slackapi/java-slack-sdk) from `1.42.0` to `1.42.1`

📜 [GitHub Release Notes](https://github.com/slackapi/java-slack-sdk/releases/tag/v1.42.1) - [Version Diff](https://github.com/slackapi/java-slack-sdk/compare/v1.42.0...v1.42.1)