### PR TITLE
munit: 1.0.1 -> 1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val effects =
     .in(file("modules/2-effects"))
     .dependsOn(domain)
     .settings(
-      libraryDependencies += "org.scalameta" %% "munit" % "1.0.1" % Test
+      libraryDependencies += "org.scalameta" %% "munit" % "1.0.2" % Test
     )
 
 lazy val use_cases =
@@ -40,7 +40,7 @@ lazy val use_cases =
       libraryDependencies += "org.jsoup" % "jsoup" % "1.18.1",
       libraryDependencies += "org.ocpsoft.prettytime" % "prettytime" % "5.0.9.Final",
       libraryDependencies += "net.objecthunter" % "exp4j" % "0.4.8",
-      libraryDependencies += "org.scalameta" %% "munit" % "1.0.1" % Test,
+      libraryDependencies += "org.scalameta" %% "munit" % "1.0.2" % Test,
       libraryDependencies += "org.scalameta" %% "munit-scalacheck" % "1.0.0" % Test
     )
     .dependsOn(domain, effects)
@@ -57,7 +57,7 @@ lazy val adaptors =
         "zio"
       ),
       libraryDependencies += "com.h2database" % "h2" % "2.3.232" % Test,
-      libraryDependencies += "org.scalameta" %% "munit" % "1.0.1" % Test
+      libraryDependencies += "org.scalameta" %% "munit" % "1.0.2" % Test
     )
     .dependsOn(effects)
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-PMp1Ty/Dp3stC6E7NKvFVcdqVEPHtPtKc5q/IqCiyd0=";
+    depsSha256 = "sha256-EuKPEWrSJoP4ZeXsjewL8/hkhOLxu5Z5oxeESIduEn0=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scalameta:munit](https://github.com/scalameta/munit) from `1.0.1` to `1.0.2`

📜 [GitHub Release Notes](https://github.com/scalameta/munit/releases/tag/v1.0.2) - [Version Diff](https://github.com/scalameta/munit/compare/v1.0.1...v1.0.2)