### PR TITLE
sbt-assembly: 2.2.0 -> 2.3.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.0")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")


### PR DESCRIPTION
📦 Updates [com.eed3si9n:sbt-assembly](https://github.com/sbt/sbt-assembly) from `2.2.0` to `2.3.0`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-assembly/releases/tag/v2.3.0) - [Version Diff](https://github.com/sbt/sbt-assembly/compare/v2.2.0...v2.3.0)