### PR TITLE
amqp-client: 5.21.0 -> 5.22.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val adaptors_with_zio =
   project
     .in(file("modules/4-adaptors-with-zio"))
     .settings(
-      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.21.0",
+      libraryDependencies += "com.rabbitmq" % "amqp-client" % "5.22.0",
       libraryDependencies += "dev.zio" %% "zio" % zioVersion,
       libraryDependencies += "dev.zio" %% "zio-json" % zioJsonVersion exclude (
         "dev.zio",


### PR DESCRIPTION
📦 Updates [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client) from `5.21.0` to `5.22.0`

📜 [GitHub Release Notes](https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.22.0) - [Version Diff](https://github.com/rabbitmq/rabbitmq-java-client/compare/v5.21.0...v5.22.0)