### PR TITLE
logback-classic: 1.5.8 -> 1.5.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val producers =
     .settings(
       moduleName := "producers",
       libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.4.1",
-      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.8",
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.9",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",
         "zio"
@@ -102,7 +102,7 @@ lazy val irc =
       moduleName := "irc",
       resolvers += "jitpack" at "https://jitpack.io/", // needed for pircbotx
       libraryDependencies += "com.github.pircbotx" % "pircbotx" % "2.3.1",
-      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.8",
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.9",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",
         "zio"
@@ -125,7 +125,7 @@ lazy val slack =
       libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.43.1",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.0",
-      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.8",
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.9",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",
         "zio"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-93OdG3DBBoSf0gFUMvdk7ib35O+HhBPvyxgp6BdcZZc=";
+    depsSha256 = "sha256-HZbHRpC8l77DklzBoQlkTH32IHEXqbHNCg+s1xVxCj4=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [ch.qos.logback:logback-classic](https://github.com/qos-ch/logback) from `1.5.8` to `1.5.9`