### PR TITLE
zio: 2.1.9 -> 2.1.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "2.1.9"
+val zioVersion = "2.1.11"
 val zioJsonVersion = "0.7.3"
 val zioLoggingVersion = "2.3.1"
 val testcontainersVersion = "0.41.4"

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-HZbHRpC8l77DklzBoQlkTH32IHEXqbHNCg+s1xVxCj4=";
+    depsSha256 = "sha256-RNCLz6rT1K9WmAvDrotYfPlNIlzgoJRMSYQwxkQgZEE=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [dev.zio:zio](https://github.com/zio/zio) from `2.1.9` to `2.1.11`

📜 [GitHub Release Notes](https://github.com/zio/zio/releases/tag/v2.1.11) - [Version Diff](https://github.com/zio/zio/compare/v2.1.9...v2.1.11)