### PR TITLE
scala3-library: 3.5.0 -> 3.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val zioJsonVersion = "0.7.3"
 val zioLoggingVersion = "2.3.1"
 val testcontainersVersion = "0.41.4"
 
-ThisBuild / scalaVersion := "3.5.0"
+ThisBuild / scalaVersion := "3.5.1"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-RNCLz6rT1K9WmAvDrotYfPlNIlzgoJRMSYQwxkQgZEE=";
+    depsSha256 = "sha256-w0hJ7HeRKOUkIfpONlMEgHAnjgUY2pjbeR9JN8o5Yvk=";
 
     src = ./.;
 


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala3-library](https://github.com/scala/scala3) from `3.5.0` to `3.5.1`

📜 [GitHub Release Notes](https://github.com/scala/scala3/releases/tag/3.5.1) - [Version Diff](https://github.com/scala/scala3/compare/3.5.0...3.5.1)