### PR TITLE
bolt-socket-mode: 1.43.1 -> 1.44.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.43.1",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.44.0",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.10",


### PR DESCRIPTION
📦 Updates [com.slack.api:bolt-socket-mode](https://github.com/slackapi/java-slack-sdk) from `1.43.1` to `1.44.0`

📜 [GitHub Release Notes](https://github.com/slackapi/java-slack-sdk/releases/tag/v1.44.0) - [Version Diff](https://github.com/slackapi/java-slack-sdk/compare/v1.43.1...v1.44.0)