### PR TITLE
mariadb-java-client: 3.4.1 -> 3.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val producers =
     .in(file("modules/5-producers"))
     .settings(
       moduleName := "producers",
-      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.4.1",
+      libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.5.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.11",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",


### PR DESCRIPTION
📦 Updates [org.mariadb.jdbc:mariadb-java-client](https://github.com/mariadb-corporation/mariadb-connector-j) from `3.4.1` to `3.5.0`

📜 [GitHub Release Notes](https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.5.0) - [Changelog](https://github.com/mariadb-corporation/mariadb-connector-j/blob/master/CHANGELOG.md) - [Version Diff](https://github.com/mariadb-corporation/mariadb-connector-j/compare/3.4.1...3.5.0)