### PR TITLE
Add JNA library to support local socket to MariaDB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,7 @@ lazy val producers =
     .settings(
       moduleName := "producers",
       libraryDependencies += "org.mariadb.jdbc" % "mariadb-java-client" % "3.5.3",
+      libraryDependencies += "net.java.dev.jna" % "jna" % "5.17.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.18",
       libraryDependencies += "dev.zio" %% "zio-logging" % zioLoggingVersion exclude (
         "dev.zio",

--- a/default.nix
+++ b/default.nix
@@ -38,7 +38,7 @@ in
     pname = "sectery";
     version = "1.0.0";
 
-    depsSha256 = "sha256-iolannen4PrgPuVewgKxP/C0eVrLSwyUdRszt8+HN6g=";
+    depsSha256 = "sha256-97os/ljLZ2xRkA7jzqmptL2lvhxyG+frxui32Ip+72Y=";
 
     src = ./.;
 


### PR DESCRIPTION
Without this, attempting to use a local socket connection (e.g. `jdbc:mariadb://localhost:3306/<db>?localSocket=/var/run/mysqld/mysqld.sock`) fails with:

```
connect: The address can't be null
  at java.base/java.net.Socket.connect(Socket.java:605)
```