### PR TITLE
bolt-socket-mode: 1.45.3 -> 1.45.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.45.3",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.45.4",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.0",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.18",


### PR DESCRIPTION
## About this PR
📦 Updates com.slack.api:bolt-socket-mode from `1.45.3` to `1.45.4`

<!-- scala-steward = {
  "Update" : {
    "ForArtifactId" : {
      "crossDependency" : [
        {
          "groupId" : "com.slack.api",
          "artifactId" : {
            "name" : "bolt-socket-mode",
            "maybeCrossName" : null
          },
          "version" : "1.45.3",
          "sbtVersion" : null,
          "scalaVersion" : null,
          "configurations" : null
        }
      ],
      "newerVersions" : [
        "1.45.4"
      ],
      "newerGroupId" : null,
      "newerArtifactId" : null
    }
  },
  "Labels" : [
    "library-update",
    "early-semver-patch",
    "semver-spec-patch",
    "commit-count:1"
  ]
} -->