### PR TITLE
bolt-socket-mode: 1.48.0 -> 1.48.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ lazy val slack =
     .in(file("modules/5-slack"))
     .settings(
       moduleName := "slack",
-      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.48.0",
+      libraryDependencies += "com.slack.api" % "bolt-socket-mode" % "1.48.1",
       libraryDependencies += "javax.websocket" % "javax.websocket-api" % "1.1" % Provided,
       libraryDependencies += "org.glassfish.tyrus.bundles" % "tyrus-standalone-client" % "2.2.2",
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.32",

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ pkgs.mkSbtDerivation {
   pname = "sectery";
   version = "0.1.0-SNAPSHOT";
 
-  depsSha256 = "sha256-Ufabz8vj+BFfQLCa10VTBa0QKoN/x1FWX0O+iDibNM0=";
+  depsSha256 = "sha256-vY6zZYamF2Y6c3/skj1zmuUy3Qpqs85GmPJ4EaCpYsA=";
 
   src = ./.;
 


### PR DESCRIPTION
## About this PR
📦 Updates com.slack.api:bolt-socket-mode from `1.48.0` to `1.48.1`

<!-- scala-steward = {
  "Update" : {
    "ForArtifactId" : {
      "crossDependency" : [
        {
          "groupId" : "com.slack.api",
          "artifactId" : {
            "name" : "bolt-socket-mode",
            "maybeCrossName" : null
          },
          "version" : "1.48.0",
          "sbtVersion" : null,
          "scalaVersion" : null,
          "configurations" : null
        }
      ],
      "newerVersions" : [
        "1.48.1"
      ],
      "newerGroupId" : null,
      "newerArtifactId" : null
    }
  },
  "Labels" : [
    "library-update",
    "early-semver-patch",
    "semver-spec-patch",
    "commit-count:1"
  ]
} -->